### PR TITLE
Feature/view sparklines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,5 @@ jobs:
         run: pnpm run tsc
       - name: Run build
         run: pnpm run build
+      - name: Run tests
+        run: pnpm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@master
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}
           registry-url: "https://registry.npmjs.org"
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4.2.0
+        uses: pnpm/action-setup@v4
       - name: Install dependencies
         run: pnpm -r install
       - name: Run TSC

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "pnpm run -r --if-present --parallel dev",
     "dev:host": "pnpm run -r --if-present --parallel dev:host",
     "build": "pnpm run -r --if-present build",
-    "tsc": "pnpm run -r --if-present tsc"
+    "tsc": "pnpm run -r --if-present tsc",
+    "test": "pnpm run -r --if-present test"
   },
   "engines": {
     "node": ">24.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@tanstack/react-router-devtools':
         specifier: ^1.163.3
         version: 1.163.3(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tanstack/router-core@1.163.3)(csstype@3.2.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.21
+        version: 3.13.21(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/router-plugin':
         specifier: ^1.164.0
         version: 1.164.0(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
@@ -1910,6 +1913,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.13.21':
+    resolution: {integrity: sha512-SYXFrmrbPgXBvf+HsOsKhFgqSe4M6B29VHOsX9Jih9TlNkNkDWx0hWMiMLUghMEzyUz772ndzdEeCEBx+3GIZw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.163.3':
     resolution: {integrity: sha512-jPptiGq/w3nuPzcMC7RNa79aU+b6OjaDzWJnBcV2UAwL4ThJamRS4h42TdhJE+oF5yH9IEnCOGQdfnbw45LbfA==}
     engines: {node: '>=20.19'}
@@ -1955,6 +1964,9 @@ packages:
 
   '@tanstack/store@0.9.1':
     resolution: {integrity: sha512-+qcNkOy0N1qSGsP7omVCW0SDrXtaDcycPqBDE726yryiA5eTDFpjBReaYjghVJwNf1pcPMyzIwTGlYjCSQR0Fg==}
+
+  '@tanstack/virtual-core@3.13.21':
+    resolution: {integrity: sha512-ww+fmLHyCbPSf7JNbWZP3g7wl6SdNo3ah5Aiw+0e9FDErkVHLKprYUrwTm7dF646FtEkN/KkAKPYezxpmvOjxw==}
 
   '@tanstack/virtual-file-routes@1.161.4':
     resolution: {integrity: sha512-42WoRePf8v690qG8yGRe/YOh+oHni9vUaUUfoqlS91U2scd3a5rkLtVsc6b7z60w3RogH0I00vdrC5AaeiZ18w==}
@@ -5349,6 +5361,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
 
+  '@tanstack/react-virtual@3.13.21(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.21
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@tanstack/router-core@1.163.3':
     dependencies:
       '@tanstack/history': 1.161.4
@@ -5417,6 +5435,8 @@ snapshots:
       - supports-color
 
   '@tanstack/store@0.9.1': {}
+
+  '@tanstack/virtual-core@3.13.21': {}
 
   '@tanstack/virtual-file-routes@1.161.4': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,6 +346,9 @@ importers:
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
+      lodash-es:
+        specifier: ^4.17.23
+        version: 4.17.23
       temporal-polyfill:
         specifier: ^0.3.0
         version: 0.3.0
@@ -353,9 +356,15 @@ importers:
         specifier: ^4.1
         version: 4.3.6
     devDependencies:
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -5611,6 +5620,14 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
 
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
+
   '@vitest/pretty-format@4.0.18':
     dependencies:
       tinyrainbow: 3.0.3
@@ -7612,6 +7629,23 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
+  vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.3.3
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      sass: 1.97.3
+      tsx: 4.21.0
+      yaml: 2.8.2
+
   vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@oxc-project/runtime': 0.115.0
@@ -7653,6 +7687,44 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.13
+      jsdom: 28.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.3.3
       jsdom: 28.1.0
     transitivePeerDependencies:
       - jiti

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
         version: 0.14.2(typescript@5.9.3)
       '@content-collections/vite':
         specifier: ^0.2.9
-        version: 0.2.9(@content-collections/core@0.14.2(typescript@5.9.3))(vite@8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
+        version: 0.2.9(@content-collections/core@0.14.2(typescript@5.9.3))(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
       '@cougargrades/atom-feed':
         specifier: workspace:*
         version: link:../../packages/atom-feed
@@ -130,7 +130,7 @@ importers:
         version: 3.13.21(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/router-plugin':
         specifier: ^1.164.0
-        version: 1.164.0(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.164.0(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
       bootstrap:
         specifier: ~5.3.8
         version: 5.3.8(@popperjs/core@2.11.8)
@@ -179,7 +179,7 @@ importers:
         version: 4.0.1
       '@tanstack/devtools-vite':
         specifier: ^0.3.12
-        version: 0.3.12(vite@8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
+        version: 0.3.12(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
       '@types/nprogress':
         specifier: ^0.2.3
         version: 0.2.3
@@ -194,7 +194,7 @@ importers:
         version: 0.20.1
       '@vitejs/plugin-react':
         specifier: ^5.1.4
-        version: 5.1.4(vite@8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
       csstype:
         specifier: ^3.2.3
         version: 3.2.3
@@ -223,8 +223,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       vite:
-        specifier: ^8.0.0-beta.16
-        version: 8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
+        specifier: ^8.0.0
+        version: 8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
 
   src/packages/atom-feed:
     dependencies:
@@ -249,7 +249,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
 
   src/packages/models:
     dependencies:
@@ -1485,79 +1485,91 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.6':
-    resolution: {integrity: sha512-kvjTSWGcrv+BaR2vge57rsKiYdVR8V8CoS0vgKrc570qRBfty4bT+1X0z3j2TaVV+kAYzA0PjeB9+mdZyqUZlg==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.6':
-    resolution: {integrity: sha512-+tJhD21KvGNtUrpLXrZQlT+j5HZKiEwR2qtcZb3vNOUpvoT9QjEykr75ZW/Kr0W89gose/HVXU6351uVZD8Qvw==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.6':
-    resolution: {integrity: sha512-DKNhjMk38FAWaHwUt1dFR3rA/qRAvn2NUvSG2UGvxvlMxSmN/qqww/j4ABAbXhNRXtGQNmrAINMXRuwHl16ZHg==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.6':
-    resolution: {integrity: sha512-8TThsRkCPAnfyMBShxrGdtoOE6h36QepqRQI97iFaQSCRbHFWHcDHppcojZnzXoruuhPnjMEygzaykvPVJsMRg==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.6':
-    resolution: {integrity: sha512-ZfmFoOwPUZCWtGOVC9/qbQzfc0249FrRUOzV2XabSMUV60Crp211OWLQN1zmQAsRIVWRcEwhJ46Z1mXGo/L/nQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    resolution: {integrity: sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.6':
-    resolution: {integrity: sha512-ZsGzbNETxPodGlLTYHaCSGVhNN/rvkMDCJYHdT7PZr5jFJRmBfmDi2awhF64Dt2vxrJqY6VeeYSgOzEbHRsb7Q==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.6':
-    resolution: {integrity: sha512-elPpdevtCdUOqziemR86C4CSCr/5sUxalzDrf/CJdMT+kZt2C556as++qHikNOz0vuFf52h+GJNXZM08eWgGPQ==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.6':
-    resolution: {integrity: sha512-IBwXsf56o3xhzAyaZxdM1CX8UFiBEUFCjiVUgny67Q8vPIqkjzJj0YKhd3TbBHanuxThgBa59f6Pgutg2OGk5A==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.6':
-    resolution: {integrity: sha512-vOk7G8V9Zm+8a6PL6JTpCea61q491oYlGtO6CvnsbhNLlKdf0bbCPytFzGQhYmCKZDKkEbmnkcIprTEGCURnwg==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.6':
-    resolution: {integrity: sha512-ASjEDI4MRv7XCQb2JVaBzfEYO98JKCGrAgoW6M03fJzH/ilCnC43Mb3ptB9q/lzsaahoJyIBoAGKAYEjUvpyvQ==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.6':
-    resolution: {integrity: sha512-mYa1+h2l6Zc0LvmwUh0oXKKYihnw/1WC73vTqw+IgtfEtv47A+rWzzcWwVDkW73+UDr0d/Ie/HRXoaOY22pQDw==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+    resolution: {integrity: sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.6':
-    resolution: {integrity: sha512-e2ABskbNH3MRUBMjgxaMjYIw11DSwjLJxBII3UgpF6WClGLIh8A20kamc+FKH5vIaFVnYQInmcLYSUVpqMPLow==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.6':
-    resolution: {integrity: sha512-dJVc3ifhaRXxIEh1xowLohzFrlQXkJ66LepHm+CmSprTWgVrPa8Fx3OL57xwIqDEH9hufcKkDX2v65rS3NZyRA==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1565,8 +1577,8 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
-  '@rolldown/pluginutils@1.0.0-rc.6':
-    resolution: {integrity: sha512-Y0+JT8Mi1mmW08K6HieG315XNRu4L0rkfCpA364HtytjgiqYnMYRdFPcxRl+BQQqNXzecL2S9nii+RUpO93XIA==}
+  '@rolldown/pluginutils@1.0.0-rc.9':
+    resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -2859,74 +2871,74 @@ packages:
   launch-editor@2.13.1:
     resolution: {integrity: sha512-lPSddlAAluRKJ7/cjRFoXUFzaX7q/YKI7yPHuEvSJVqoXvFnJov1/Ud87Aa4zULIbA9Nja4mSPK8l0z/7eV2wA==}
 
-  lightningcss-android-arm64@1.31.1:
-    resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
-  lightningcss-darwin-arm64@1.31.1:
-    resolution: {integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==}
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.31.1:
-    resolution: {integrity: sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==}
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.31.1:
-    resolution: {integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==}
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.31.1:
-    resolution: {integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==}
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm64-gnu@1.31.1:
-    resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-arm64-musl@1.31.1:
-    resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-x64-gnu@1.31.1:
-    resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
 
-  lightningcss-linux-x64-musl@1.31.1:
-    resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
 
-  lightningcss-win32-arm64-msvc@1.31.1:
-    resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  lightningcss-win32-x64-msvc@1.31.1:
-    resolution: {integrity: sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==}
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
 
-  lightningcss@1.31.1:
-    resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lines-and-columns@1.2.4:
@@ -3421,8 +3433,8 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
-  rolldown@1.0.0-rc.6:
-    resolution: {integrity: sha512-B8vFPV1ADyegoYfhg+E7RAucYKv0xdVlwYYsIJgfPNeiSxZGWNxts9RqhyGzC11ULK/VaeXyKezGCwpMiH8Ktw==}
+  rolldown@1.0.0-rc.9:
+    resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -3817,8 +3829,8 @@ packages:
       yaml:
         optional: true
 
-  vite@8.0.0-beta.16:
-    resolution: {integrity: sha512-c0t7hYkxsjws89HH+BUFh/sL3BpPNhNsL9CJrTpMxBmwKQBRSa5OJ5w4o9O0bQVI/H/vx7UpUUIevvXa37NS/Q==}
+  vite@8.0.0:
+    resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4222,11 +4234,11 @@ snapshots:
     dependencies:
       '@content-collections/core': 0.14.2(typescript@5.9.3)
 
-  '@content-collections/vite@0.2.9(@content-collections/core@0.14.2(typescript@5.9.3))(vite@8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))':
+  '@content-collections/vite@0.2.9(@content-collections/core@0.14.2(typescript@5.9.3))(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@content-collections/core': 0.14.2(typescript@5.9.3)
       '@content-collections/integrations': 0.5.0(@content-collections/core@0.14.2(typescript@5.9.3))
-      vite: 8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
 
   '@cougargrades/firebase-rest-firestore@1.6.1':
     dependencies:
@@ -5024,50 +5036,56 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.6':
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.6':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.6':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.6':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.6':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.6':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.6':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.6':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.6':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.6':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.6':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
     dependencies:
       '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.6':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.6':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.6': {}
+  '@rolldown/pluginutils@1.0.0-rc.9': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -5276,7 +5294,7 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools-vite@0.3.12(vite@8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tanstack/devtools-vite@0.3.12(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -5288,7 +5306,7 @@ snapshots:
       chalk: 5.6.2
       launch-editor: 2.13.1
       picomatch: 4.0.3
-      vite: 8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5399,7 +5417,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.164.0(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tanstack/router-plugin@1.164.0(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -5416,7 +5434,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      vite: 8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5564,7 +5582,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@5.1.4(vite@8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.1.4(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5572,7 +5590,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5585,13 +5603,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -6410,54 +6428,54 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.3
 
-  lightningcss-android-arm64@1.31.1:
+  lightningcss-android-arm64@1.32.0:
     optional: true
 
-  lightningcss-darwin-arm64@1.31.1:
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
-  lightningcss-darwin-x64@1.31.1:
+  lightningcss-darwin-x64@1.32.0:
     optional: true
 
-  lightningcss-freebsd-x64@1.31.1:
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.31.1:
+  lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.31.1:
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.31.1:
+  lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
-  lightningcss-linux-x64-gnu@1.31.1:
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.31.1:
+  lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
-  lightningcss-win32-arm64-msvc@1.31.1:
+  lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.31.1:
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
-  lightningcss@1.31.1:
+  lightningcss@1.32.0:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-android-arm64: 1.31.1
-      lightningcss-darwin-arm64: 1.31.1
-      lightningcss-darwin-x64: 1.31.1
-      lightningcss-freebsd-x64: 1.31.1
-      lightningcss-linux-arm-gnueabihf: 1.31.1
-      lightningcss-linux-arm64-gnu: 1.31.1
-      lightningcss-linux-arm64-musl: 1.31.1
-      lightningcss-linux-x64-gnu: 1.31.1
-      lightningcss-linux-x64-musl: 1.31.1
-      lightningcss-win32-arm64-msvc: 1.31.1
-      lightningcss-win32-x64-msvc: 1.31.1
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lines-and-columns@1.2.4: {}
 
@@ -7174,24 +7192,26 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rolldown@1.0.0-rc.6:
+  rolldown@1.0.0-rc.9:
     dependencies:
       '@oxc-project/types': 0.115.0
-      '@rolldown/pluginutils': 1.0.0-rc.6
+      '@rolldown/pluginutils': 1.0.0-rc.9
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.6
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.6
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.6
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.6
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.6
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.6
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.6
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.6
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.6
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.6
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.6
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.6
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.6
+      '@rolldown/binding-android-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.9
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.9
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.9
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.9
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
 
   rollup@4.59.0:
     dependencies:
@@ -7575,7 +7595,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -7587,18 +7607,18 @@ snapshots:
       '@types/node': 24.10.13
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.31.1
+      lightningcss: 1.32.0
       sass: 1.97.3
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2):
+  vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@oxc-project/runtime': 0.115.0
-      lightningcss: 1.31.1
+      lightningcss: 1.32.0
       picomatch: 4.0.3
       postcss: 8.5.8
-      rolldown: 1.0.0-rc.6
+      rolldown: 1.0.0-rc.9
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.3.3
@@ -7609,10 +7629,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -7629,7 +7649,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.13

--- a/src/apps/api/src/index.ts
+++ b/src/apps/api/src/index.ts
@@ -21,18 +21,7 @@ import popularity_contest from './routes/popularity_contest'
 const app = new Hono()
 
 app.use('*', cors({
-  origin: (
-    env.CORS_ALLOW_ALL === 'true'
-    ? '*'
-    : [
-      "http://localhost:3000",
-      "http://localhost:5173",
-      "http://localhost:4173",
-      "https://cougargrades.io",
-      "https://next.cougargrades.io",
-      "https://next2.cougargrades.io"
-    ]
-  ),
+  origin: '*',
   allowMethods: ['POST', 'GET', 'OPTIONS'],
   maxAge: 600,
 }));

--- a/src/apps/api/src/lib/getTopResults.ts
+++ b/src/apps/api/src/lib/getTopResults.ts
@@ -188,7 +188,7 @@ export async function getRankForInstructor(instructorName: string, { metric, tim
     const nowUTC = Temporal.Now.zonedDateTimeISO(UTC_TIMEZONE_ID);
     const timeRange = GetTimeRangeFromDurationBeforeNow(nowUTC, topDuration);
 
-    const pathname = DocumentPathToPathname(`catalog/${instructorName}`);
+    const pathname = DocumentPathToPathname(`instructors/${instructorName}`);
     if (isNullish(pathname)) return null;
 
     // Get the top visited PopCon pathnames 
@@ -258,7 +258,7 @@ export async function getSparklineForInstructor(instructorName: string, { metric
     const timeRange = GetTimeRangeFromDurationBeforeNow(nowUTC, topDuration);
     const binSize = TopTime2BinSize.get(time) ?? Temporal.Duration.from({ days: 1 });
 
-    const pathname = DocumentPathToPathname(`catalog/${instructorName}`);
+    const pathname = DocumentPathToPathname(`instructors/${instructorName}`);
     if (isNullish(pathname)) return null;
 
     // Get the top visited PopCon pathnames 

--- a/src/apps/api/src/lib/getTopResults.ts
+++ b/src/apps/api/src/lib/getTopResults.ts
@@ -1,11 +1,11 @@
 
-import { DocumentPathToPathname, PathnameToDocumentPath, PopConMetric, PopConMetric2PlusMetricKey, TopMetric2PopConMetric } from '@cougargrades/models'
+import { BinnedSparklineData, DocumentPathToPathname, PathnameToDocumentPath, PopConMetric, PopConMetric2PlusMetricKey, SparklineData, TopMetric2PopConMetric } from '@cougargrades/models'
 import { stream } from '@cougargrades/vendor/firestore'
-import { CoursePlusMetrics, InstructorPlusMetrics, RankingResult, TopOptions, TopResult, TopTime2Duration, ToTopResult } from '@cougargrades/models/dto'
+import { CoursePlusMetrics, InstructorPlusMetrics, RankingResult, TopOptions, TopResult, TopTime2BinSize, TopTime2Duration, ToTopResult } from '@cougargrades/models/dto'
 import core_curriculum_json from '@cougargrades/publicdata/bundle/edu.uh.publications.core/core_curriculum.json'
 import { Temporal } from 'temporal-polyfill';
 import { firestore, getFirestoreDocumentSafe } from './firestore-config'
-import { getPopConTopPages, getRankForPathname, PopConTopResult, streamPopConTopPages } from './popconHelper';
+import { getPopConTopPages, getRankForPathname, getSparklineForPathname, PopConTopResult, streamPopConTopPages } from './popconHelper';
 import { isNullish } from '@cougargrades/utils/nullish'
 import { GetTimeRangeFromDurationBeforeNow, UTC_TIMEZONE_ID } from '@cougargrades/utils/temporal'
 
@@ -199,6 +199,76 @@ export async function getRankForInstructor(instructorName: string, { metric, tim
     })
 
     return rank;
+  }
+
+  return null;
+}
+
+/**
+ * Used to get the ranking for a Course based on `TopOptions`
+ * @param courseName 
+ * @param param1 
+ * @returns 
+ */
+export async function getSparklineForCourse(courseName: string, { metric, time }: Pick<TopOptions, 'metric' | 'time'>): Promise<BinnedSparklineData | null> {
+  if (metric === 'totalEnrolled') {
+    // TODO: this is not yet supported
+    return null
+  }
+  else if (metric === 'pageView') {
+    // Convert `Top` parameters into `PopCon` parameters
+    const pMetric = TopMetric2PopConMetric.get(metric) ?? PopConMetric.PageView;
+    const topDuration = TopTime2Duration.get(time) ?? Temporal.Duration.from({ years: 999 });
+    const nowUTC = Temporal.Now.zonedDateTimeISO(UTC_TIMEZONE_ID);
+    const timeRange = GetTimeRangeFromDurationBeforeNow(nowUTC, topDuration);
+    const binSize = TopTime2BinSize.get(time) ?? Temporal.Duration.from({ days: 1 });
+
+    const pathname = DocumentPathToPathname(`catalog/${courseName}`);
+    if (isNullish(pathname)) return null;
+
+    // Get the top visited PopCon pathnames 
+    const sparkline = await getSparklineForPathname(pathname, binSize, {
+      metric: pMetric,
+      topic: 'course',
+      timeRange
+    })
+
+    return sparkline;
+  }
+
+  return null;
+}
+
+/**
+ * Used to get the ranking for an Instructor based on `TopOptions`
+ * @param instructorName 
+ * @param param1 
+ * @returns 
+ */
+export async function getSparklineForInstructor(instructorName: string, { metric, time }: Pick<TopOptions, 'metric' | 'time'>): Promise<BinnedSparklineData | null> {
+  if (metric === 'totalEnrolled') {
+    // TODO: this is not yet supported
+    return null
+  }
+  else if (metric === 'pageView') {
+    // Convert `Top` parameters into `PopCon` parameters
+    const pMetric = TopMetric2PopConMetric.get(metric) ?? PopConMetric.PageView;
+    const topDuration = TopTime2Duration.get(time) ?? Temporal.Duration.from({ years: 999 });
+    const nowUTC = Temporal.Now.zonedDateTimeISO(UTC_TIMEZONE_ID);
+    const timeRange = GetTimeRangeFromDurationBeforeNow(nowUTC, topDuration);
+    const binSize = TopTime2BinSize.get(time) ?? Temporal.Duration.from({ days: 1 });
+
+    const pathname = DocumentPathToPathname(`catalog/${instructorName}`);
+    if (isNullish(pathname)) return null;
+
+    // Get the top visited PopCon pathnames 
+    const sparkline = await getSparklineForPathname(pathname, binSize, {
+      metric: pMetric,
+      topic: 'instructor',
+      timeRange
+    })
+
+    return sparkline;
   }
 
   return null;

--- a/src/apps/api/src/lib/getTopResults.ts
+++ b/src/apps/api/src/lib/getTopResults.ts
@@ -18,12 +18,13 @@ const core_curriculum_pathnames = new Set(
 
 export const CourseOrInstructorPlusMetrics = CoursePlusMetrics.or(InstructorPlusMetrics);
 
-export async function getTopResults({ metric, topic, limit, time, hideCore }: TopOptions): Promise<TopResult[]> {
+export async function getTopResults({ metric, topic, limit, skip, time, hideCore }: TopOptions): Promise<TopResult[]> {
   const seen = new Set<string>();
   if (metric === 'totalEnrolled') {
     const db = firestore();
     const query = db.collection(topic === 'course' ? 'catalog' : 'instructors')
-        .orderBy('enrollment.totalEnrolled', 'desc');
+        .orderBy('enrollment.totalEnrolled', 'desc')
+        .offset(skip);
     
     let result: (CoursePlusMetrics | InstructorPlusMetrics)[] = [];
 
@@ -73,7 +74,7 @@ export async function getTopResults({ metric, topic, limit, time, hideCore }: To
      * Stream it because it's the most syntactically simple
      * way to keep asking for more if we find rows that we don't want (core curriculum filter).
      */
-    for await (const row of streamPopConTopPages({ metric: pMetric, topic, timeRange, chunkSize: limit })) {
+    for await (const row of streamPopConTopPages({ metric: pMetric, topic, timeRange, offset: skip, chunkSize: limit })) {
       // End the stream if we capture the amount we want
       if (rankedPopcons.length >= limit) break;
 

--- a/src/apps/api/src/lib/popconHelper.ts
+++ b/src/apps/api/src/lib/popconHelper.ts
@@ -252,21 +252,25 @@ export async function getSparklineForPathname(pathname: string, binSize: Tempora
   }
   const qTimeRange: [Temporal.ZonedDateTime, Temporal.ZonedDateTime] = timeRange ?? [COUGAR_GRADES_EARLIEST_ANALYTICS_DATE, Temporal.Now.zonedDateTimeISO(UTC_TIMEZONE_ID)]
 
-  const pathname_LIKE = (
-    topic === 'course'
-    ? '/c/%'
-    : (
-      topic === 'instructor'
-      ? '/i/%'
-      : '%'
-    )
-  );
+  // const pathname_LIKE = (
+  //   topic === 'course'
+  //   ? '/c/%'
+  //   : (
+  //     topic === 'instructor'
+  //     ? '/i/%'
+  //     : '%'
+  //   )
+  // );
 
   const binSizeSeconds = Math.floor(Math.abs(binSize.total({ unit: 'seconds', relativeTo: Temporal.Now.zonedDateTimeISO() })));
 
+  /**
+   * These are all the bins, not just what the SQL has.
+   * An entry in here should be IDENTICAL, to what is found in the SQL side.
+   */
   const bins = Array.from(
     GenerateBins(ToEpochSeconds(qTimeRange[0]), ToEpochSeconds(qTimeRange[1]), binSizeSeconds)
-  );
+  ).slice(0, -1);
 
   /**
    * Get the max Y-value given:
@@ -343,10 +347,18 @@ export async function getSparklineForPathname(pathname: string, binSize: Tempora
   })
 
   const result: BinnedSparklineData = {
-    data: rows.map(r => r.metric_sum),
-    xAxis: rows.map(r => {
-      const start = EpochSecondsToDate(r.bin_start);
-      const end = EpochSecondsToDate(r.bin_start + binSizeSeconds);
+    // data: rows.map(r => r.metric_sum),
+    // xAxis: rows.map(r => {
+    //   const start = EpochSecondsToDate(r.bin_start);
+    //   const end = EpochSecondsToDate(r.bin_start + binSizeSeconds);
+    //   return formatter.formatRange(start, end);
+    // }),
+    data: bins.map(b =>
+      rows.find(r => r.bin_start === b)?.metric_sum ?? 0
+    ),
+    xAxis: bins.map(bin => {
+      const start = EpochSecondsToDate(bin);
+      const end = EpochSecondsToDate(bin + binSizeSeconds);
       return formatter.formatRange(start, end);
     }),
     yAxis: {

--- a/src/apps/api/src/lib/popconHelper.ts
+++ b/src/apps/api/src/lib/popconHelper.ts
@@ -1,13 +1,18 @@
 import { parse, z } from 'zod'
-import { DocumentPathToPathname, PathnameToDocumentPath, PopCon, PopConOptions, ToEpochSeconds } from '@cougargrades/models'
+import { BinnedSparklineData, DocumentPathToPathname, PathnameToDocumentPath, PopCon, PopConOptions, } from '@cougargrades/models'
 import { RankingResult } from '@cougargrades/models/dto'
 import { isNullish, isNullishOrWhitespace } from '@cougargrades/utils/nullish';
-import { UTC_TIMEZONE_ID } from "@cougargrades/utils/temporal"
+import { EpochSecondsToDate, EpochSecondsToTemporal, GetNowDateEpochSeconds, IsABeforeB, ToEpochSeconds, UTC_TIMEZONE_ID } from "@cougargrades/utils/temporal"
 import { env } from 'cloudflare:workers'
 import { Temporal } from 'temporal-polyfill';
 import { getFirestoreDocumentSafe } from './firestore-config'
 
 const EPOCH_START = Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO(UTC_TIMEZONE_ID);
+
+/**
+ * The earliest date we have analytics available, based on the Google Analytics import.
+ */
+const COUGAR_GRADES_EARLIEST_ANALYTICS_DATE = Temporal.Instant.fromEpochMilliseconds(1643846400 * 1000).toZonedDateTimeISO(UTC_TIMEZONE_ID);
 
 /**
  * Allows using D1 SQLite with sql`` template literals safely
@@ -198,8 +203,7 @@ export async function getRankForPathname(pathname: string, { metric, timeRange, 
         PopularityContest
       WHERE
         metric_type = ${metric}
-        AND date_epoch_seconds >= ${ToEpochSeconds(qTimeRange[0])}
-        AND date_epoch_seconds <= ${ToEpochSeconds(qTimeRange[1])}
+        AND date_epoch_seconds BETWEEN ${ToEpochSeconds(qTimeRange[0])} AND ${ToEpochSeconds(qTimeRange[1])}
         AND pathname LIKE ${pathname_LIKE}
         AND pathname NOT IN (${qExclude})
       GROUP BY
@@ -218,4 +222,149 @@ export async function getRankForPathname(pathname: string, { metric, timeRange, 
   // We want a failed parse to throw an error
   const parsed = RankingResult.array().parse(res?.results);
   return parsed.at(0) ?? null;
+}
+
+/**
+ * Looks up the rank of an individual page (via `pathname`) that follows PopConOptions.
+ * This should give the same result as the position in `getPopConTopPages()`
+ * 
+ * This uses the SQLite `RANK()` function. 
+ * 
+ * A comparison:
+ * - RANK() => Ties share rank, gaps appear (1,2,2,4)
+ * - DENSE_RANK() => Ties share rank, no gaps (1,2,2,3)
+ * - ROW_NUMBER() => No ties, strictly sequential
+ * 
+ * @param options PopConOptions
+ * @returns 
+ */
+export async function getSparklineForPathname(pathname: string, binSize: Temporal.Duration, { metric, timeRange, topic }: Pick<PopConOptions, 'metric' | 'timeRange' | 'topic'>): Promise<BinnedSparklineData> {
+  
+  if (!!timeRange) {
+    // Overwrite the time range with the earliest available, if it's before. (it affects the binning)
+    if (IsABeforeB(timeRange[0], COUGAR_GRADES_EARLIEST_ANALYTICS_DATE)) {
+      timeRange[0] = COUGAR_GRADES_EARLIEST_ANALYTICS_DATE;
+    }
+    // If the timeRange goes after the present time, reset it to the current time. (it affects binning)
+    if (IsABeforeB(GetNowDateEpochSeconds(), timeRange[1])) {
+      timeRange[1] = GetNowDateEpochSeconds();
+    }
+  }
+  const qTimeRange: [Temporal.ZonedDateTime, Temporal.ZonedDateTime] = timeRange ?? [COUGAR_GRADES_EARLIEST_ANALYTICS_DATE, Temporal.Now.zonedDateTimeISO(UTC_TIMEZONE_ID)]
+
+  const pathname_LIKE = (
+    topic === 'course'
+    ? '/c/%'
+    : (
+      topic === 'instructor'
+      ? '/i/%'
+      : '%'
+    )
+  );
+
+  const binSizeSeconds = Math.floor(Math.abs(binSize.total({ unit: 'seconds', relativeTo: Temporal.Now.zonedDateTimeISO() })));
+
+  const bins = Array.from(
+    GenerateBins(ToEpochSeconds(qTimeRange[0]), ToEpochSeconds(qTimeRange[1]), binSizeSeconds)
+  );
+
+  /**
+   * Get the max Y-value given:
+   * - Same metric
+   * - Same time range
+   * - Same topic (course vs instructor)
+   * 
+   * This is needed to appropriately set the Y-axis between charts for different courses/instructors
+   */
+  // Wrong query
+  // const yAxisMaxValue = z.number().int().parse(
+  //   (await sql`
+  //     SELECT MAX(sub_binned.metric_sum) AS max_metric_count
+  //     FROM (
+  //       SELECT
+  //         (date_epoch_seconds - CAST(${ToEpochSeconds(qTimeRange[0])} AS INTEGER)) / CAST(${binSizeSeconds} AS INTEGER) AS bin_index,
+  //         CAST(${ToEpochSeconds(qTimeRange[0])} AS INTEGER) + (
+  //         ((date_epoch_seconds - CAST(${ToEpochSeconds(qTimeRange[0])} AS INTEGER)) / CAST(${binSizeSeconds} AS INTEGER))
+  //         * CAST(${binSizeSeconds} AS INTEGER)
+  //         ) AS bin_start,
+  //         SUM(metric_count)       AS metric_sum
+  //       FROM PopularityContest
+  //       WHERE
+  //         date_epoch_seconds BETWEEN ${ToEpochSeconds(qTimeRange[0])} AND ${ToEpochSeconds(qTimeRange[1])}
+  //         AND pathname LIKE ${pathname_LIKE}
+  //         AND metric_type = ${metric}
+  //       GROUP BY
+  //         bin_index
+  //       ORDER BY
+  //         bin_index
+  //     ) AS sub_binned;
+  //   `)?.results.at(0)?.['max_metric_count']
+  // );
+
+  /**
+   * Generate the chart given:
+   * - Specified metric
+   * - Specified time range
+   * - Specified pathname exact match
+   */
+
+  const res = await sql`
+    SELECT
+      (date_epoch_seconds - CAST(${ToEpochSeconds(qTimeRange[0])} AS INTEGER)) / CAST(${binSizeSeconds} AS INTEGER) AS bin_index,
+      CAST(${ToEpochSeconds(qTimeRange[0])} AS INTEGER) + (
+      ((date_epoch_seconds - CAST(${ToEpochSeconds(qTimeRange[0])} AS INTEGER)) / CAST(${binSizeSeconds} AS INTEGER))
+      * CAST(${binSizeSeconds} AS INTEGER)
+      ) AS bin_start,
+      SUM(metric_count)       AS metric_sum
+    FROM PopularityContest
+    WHERE
+      date_epoch_seconds BETWEEN ${ToEpochSeconds(qTimeRange[0])} AND ${ToEpochSeconds(qTimeRange[1])}
+      AND pathname           = ${pathname}
+      AND metric_type        = ${metric}
+    GROUP BY
+      bin_index
+    ORDER BY
+      bin_index;
+  `;
+
+  const rowSchema = z.object({
+    bin_index: z.number(),
+    bin_start: z.number(),
+    metric_sum: z.number(),
+  })
+
+  // We want a failed parse to throw an error
+  const rows = rowSchema.array().parse(res?.results);
+
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  })
+
+  const result: BinnedSparklineData = {
+    data: rows.map(r => r.metric_sum),
+    xAxis: rows.map(r => {
+      const start = EpochSecondsToDate(r.bin_start);
+      const end = EpochSecondsToDate(r.bin_start + binSizeSeconds);
+      return formatter.formatRange(start, end);
+    }),
+    yAxis: {
+      min: 0,
+      //max: yAxisMaxValue,
+      max: -1
+    }
+  };
+
+  return result;
+}
+
+export function *GenerateBins(start: number, end: number, binSize: number) {
+  yield start;
+  let cursor = start;
+  do {
+    cursor += binSize;
+    yield cursor;
+  }
+  while (cursor < end);
 }

--- a/src/apps/api/src/lib/popconHelper.ts
+++ b/src/apps/api/src/lib/popconHelper.ts
@@ -146,8 +146,8 @@ export async function getPopConTopPages({ metric, limit, offset, timeRange, topi
  * Wrapper around `getPopConTopPages(...)` to support streaming
  * @param param0 
  */
-export async function* streamPopConTopPages({ metric, timeRange, topic, exclude, chunkSize }: Omit<PopConOptions, 'limit' | 'offset'> & { chunkSize: number }) {
-  let offset = 0;
+export async function* streamPopConTopPages({ metric, timeRange, topic, offset: initialOffset, exclude, chunkSize }: Omit<PopConOptions, 'limit'> & { chunkSize: number }) {
+  let offset = initialOffset;
   let snap: PopConTopResult[];
   do {
     snap = await getPopConTopPages({

--- a/src/apps/api/src/routes/top.ts
+++ b/src/apps/api/src/routes/top.ts
@@ -31,9 +31,9 @@ app.get('/',
     cacheControl: NO_CACHE ? undefined : TEMPORAL_CACHE_CONTROL(TOP_RECENT_CACHE_LIFETIME),
   }),
   async (ctx) => {
-    const { metric, topic, limit, time, hideCore } = ctx.req.valid('query');
+    const { metric, topic, limit, skip, time, hideCore } = ctx.req.valid('query');
 
-    const results = await getTopResults({ metric, topic, limit, time, hideCore })
+    const results = await getTopResults({ metric, topic, limit, skip, time, hideCore })
     return ctx.json(results);
   }
 )

--- a/src/apps/api/src/routes/top.ts
+++ b/src/apps/api/src/routes/top.ts
@@ -7,7 +7,8 @@ import { Temporal } from 'temporal-polyfill'
 import { TEMPORAL_CACHE_CONTROL } from '@cougargrades/utils/cacheControl'
 import { RankingResult, TopOptions, TopResult } from '@cougargrades/models/dto'
 import { DURATION_ZERO, NO_CACHE } from '../cache'
-import { getRankForCourse, getRankForInstructor, getTopResults } from '../lib/getTopResults'
+import { getRankForCourse, getRankForInstructor, getSparklineForCourse, getSparklineForInstructor, getTopResults } from '../lib/getTopResults'
+import { BinnedSparklineData, SparklineData } from '@cougargrades/models'
 
 export const TOP_RECENT_CACHE_LIFETIME = Temporal.Duration.from({ days: 7 });
 
@@ -87,6 +88,60 @@ app.get('/',
     const { metric, time } = ctx.req.valid('query');
 
     const rank = await getRankForInstructor(instructorName, { metric, time });
+    return ctx.json(rank);
+  }
+)
+.get('/sparkline/course/:courseName',
+  validator('param', z.object({
+    courseName: z.string()
+  })),
+  validator('query', TopOptions.pick({ metric: true, time: true })),
+  describeRoute({
+    responses: {
+      200: {
+        description: '',
+        content: {
+          'application/json': { schema: resolver(BinnedSparklineData.nullable()) }
+        }
+      }
+    }
+  }),
+  cache({
+    cacheName: 'cougargrades-api',
+    cacheControl: NO_CACHE ? undefined : TEMPORAL_CACHE_CONTROL(TOP_RECENT_CACHE_LIFETIME),
+  }),
+  async (ctx) => {
+    const { courseName } = ctx.req.valid('param');
+    const { metric, time } = ctx.req.valid('query');
+
+    const rank = await getSparklineForCourse(courseName, { metric, time });
+    return ctx.json(rank);
+  }
+)
+.get('/sparkline/instructor/:instructorName',
+  validator('param', z.object({
+    instructorName: z.string()
+  })),
+  validator('query', TopOptions.pick({ metric: true, time: true })),
+  describeRoute({
+    responses: {
+      200: {
+        description: '',
+        content: {
+          'application/json': { schema: resolver(BinnedSparklineData.nullable()) }
+        }
+      }
+    }
+  }),
+  cache({
+    cacheName: 'cougargrades-api',
+    cacheControl: NO_CACHE ? undefined : TEMPORAL_CACHE_CONTROL(TOP_RECENT_CACHE_LIFETIME),
+  }),
+  async (ctx) => {
+    const { instructorName } = ctx.req.valid('param');
+    const { metric, time } = ctx.req.valid('query');
+
+    const rank = await getSparklineForInstructor(instructorName, { metric, time });
     return ctx.json(rank);
   }
 )

--- a/src/apps/web/package.json
+++ b/src/apps/web/package.json
@@ -9,7 +9,7 @@
     "dev:host": "VITE_VERSION=$npm_package_version; VITE_BUILD_DATE=$(node -e 'process.stdout.write(new Date().toISOString())'); VITE_CF_PAGES_BRANCH=$CF_PAGES_BRANCH; VITE_CF_PAGES_COMMIT_SHA=$CF_PAGES_COMMIT_SHA; VITE_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD); VITE_COMMIT_SHA=$(git rev-parse HEAD); VITE_ENVIRONMENT_NAME=development; vite dev --port 3000 --host 0.0.0.0",
     "__$comment__2": "Run locally against the Production API (or something else specified by `VITE_API_ORIGIN` environment variable)",
     "dev:prod": "VITE_VERSION=$npm_package_version; VITE_BUILD_DATE=$(node -e 'process.stdout.write(new Date().toISOString())'); VITE_CF_PAGES_BRANCH=$CF_PAGES_BRANCH; VITE_CF_PAGES_COMMIT_SHA=$CF_PAGES_COMMIT_SHA; VITE_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD); VITE_COMMIT_SHA=$(git rev-parse HEAD); VITE_ENVIRONMENT_NAME=development; vite dev --port 3000",
-    "build": "VITE_VERSION=$npm_package_version; VITE_BUILD_DATE=$(node -e 'process.stdout.write(new Date().toISOString())'); VITE_CF_PAGES_BRANCH=$CF_PAGES_BRANCH; VITE_CF_PAGES_COMMIT_SHA=$CF_PAGES_COMMIT_SHA; VITE_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD); VITE_COMMIT_SHA=$(git rev-parse HEAD); tsc -b && vite build",
+    "build": "VITE_VERSION=$npm_package_version; VITE_BUILD_DATE=$(node -e 'process.stdout.write(new Date().toISOString())'); VITE_CF_PAGES_URL=$CF_PAGES_URL;VITE_CF_PAGES_BRANCH=$CF_PAGES_BRANCH; VITE_CF_PAGES_COMMIT_SHA=$CF_PAGES_COMMIT_SHA; VITE_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD); VITE_COMMIT_SHA=$(git rev-parse HEAD); tsc -b && vite build",
     "preview": "vite preview",
     "start": "pnpx srvx --prod -s ../client dist/server/server.js",
     "tsc": "tsc"

--- a/src/apps/web/package.json
+++ b/src/apps/web/package.json
@@ -70,6 +70,6 @@
     "remark-rehype": "^11.1.2",
     "typescript": "^5",
     "unist-util-visit": "^5.1.0",
-    "vite": "^8.0.0-beta.16"
+    "vite": "^8.0.0"
   }
 }

--- a/src/apps/web/package.json
+++ b/src/apps/web/package.json
@@ -36,6 +36,7 @@
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-router": "^1.163.3",
     "@tanstack/react-router-devtools": "^1.163.3",
+    "@tanstack/react-virtual": "^3.13.21",
     "@tanstack/router-plugin": "^1.164.0",
     "bootstrap": "~5.3.8",
     "jotai": "^2.18.0",

--- a/src/apps/web/src/components/TopListItem.tsx
+++ b/src/apps/web/src/components/TopListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import z from 'zod'
 import { Link } from '@tanstack/react-router'
 import { useTheme } from '@mui/material/styles'
 import ListItemButton from '@mui/material/ListItemButton';
@@ -10,20 +10,23 @@ import Tooltip from '@mui/material/Tooltip';
 import { SparkLineChart } from '@mui/x-charts/SparkLineChart';
 import { areaElementClasses } from '@mui/x-charts/LineChart';
 import { Badge } from './badge'
-import type { TopMetric, TopResult } from '@cougargrades/models/dto';
-
+import { arrayLastEntries, formatTermCode } from '@cougargrades/models';
+import { TopMetric, type TopOptions, type TopResult, type TopTopic } from '@cougargrades/models/dto';
+import { is } from '@cougargrades/utils/zod';
 
 
 import styles from './TopListItem.module.scss'
 //import interactivity from '../../styles/interactivity.module.scss'
 import instructorCardStyles from './instructorcard.module.scss'
-import { arrayLastEntries, formatTermCode } from '@cougargrades/models';
+import { useTopSparkline } from '../lib/services/useTopSparkline';
+import { useEffect } from 'react';
+import { isNullish } from '@cougargrades/utils/nullish';
 
 
 interface TopListItemProps {
   data: TopResult;
   index: number;
-  viewMetric: TopMetric;
+  options: Pick<TopOptions, 'metric' | 'time' | 'topic'>,
   hidePosition?: boolean;
 }
 
@@ -38,11 +41,30 @@ export function AreaGradient({ id, color, opacity }: { id: string, color: string
   );
 }
 
-export function TopListItem({ data: item, index, viewMetric, hidePosition }: TopListItemProps) {
+const TopMetric2ValueVerb: Record<TopMetric, string> = {
+  'totalEnrolled': `{0} enrolled`,
+  'pageView': `{0} views`
+}
+
+export function TopListItem({ data: item, index, options, hidePosition }: TopListItemProps) {
+  const { metric, time, topic } = options;
   const theme = useTheme();
   // This is used because it looks prettier with the transparency and draws less attention to it
   const dynamicPrimaryColor = theme.palette.mode === 'light' ? theme.palette.primary.light : theme.palette.primary.dark;
+  const dynamicWarningColor = theme.palette.mode === 'light' ? theme.palette.warning.light : theme.palette.warning.dark;
   //console.log('item?', item);
+
+  const TopMetric2ChartColor: Record<TopMetric, string> = {
+    'totalEnrolled': dynamicPrimaryColor,
+    'pageView': dynamicWarningColor,
+  }
+
+  const { data: binnedSparklineData, isPending: isPendingSparklineData } = useTopSparkline(item.id, options);
+
+  // useEffect(() => {
+  //   console.log('binnedSparklineData?', binnedSparklineData);
+  // }, [binnedSparklineData]);
+
   return (
     <Link to={item.href} className="nostyle">
       <ListItemButton alignItems="flex-start">
@@ -96,48 +118,105 @@ export function TopListItem({ data: item, index, viewMetric, hidePosition }: Top
         />
         <div className={styles.metricSparklineContainer}>
           <Typography className={styles.hintedMetric} variant="body2" color="text.secondary" noWrap>
-            {item.metricFormatted}{ viewMetric === 'totalEnrolled' ? <span className={styles.hintedMetricExtended}>{' '}since {item.metricTimeSpanFormatted}</span> : null}
+            {item.metricFormatted}{ metric === 'totalEnrolled' ? <span className={styles.hintedMetricExtended}>{' '}since {item.metricTimeSpanFormatted}</span> : null}
           </Typography>
           {
-            item.sparklineData !== undefined
-            ? <>
-              <SparkLineChart
-                //data={item.sparklineData.data} // all data
-                data={arrayLastEntries(item.sparklineData.data, 3 * 10)} // last 10 years
-                height={100}
-                area
-                color={dynamicPrimaryColor}
-                curve="linear"
-                showHighlight
-                showTooltip
-                valueFormatter={(value: number | null) => value === null ? `N/A` : `${value} enrolled`}
-                xAxis={{
-                  scaleType: 'point',
-                  //data: item.sparklineData.xAxis, // all data
-                  data: arrayLastEntries(item.sparklineData.xAxis, 3 * 10), // last 10 years
-                  valueFormatter: (value) => typeof value === 'number' ? formatTermCode(value) : value,
-                }}
-                yAxis={{
-                  // min: undefined,
-                  // max: undefined,
-                  min: item.sparklineData.yAxis.min,
-                  max: item.sparklineData.yAxis.max,
-                  // min: item.href.startsWith('/c/') ? item.sparklineData.yAxis.min : undefined,
-                  // max: item.href.startsWith('/c/') ? item.sparklineData.yAxis.max : undefined,
-                }}
-                sx={{
-                  maxWidth: '150px',
-                  [`& .${areaElementClasses.root}`]: {
-                    fill: `url(#sparkline-area-gradient)`,
-                  },
-                }}
-                >
-                <AreaGradient id="sparkline-area-gradient" color={dynamicPrimaryColor} />
-              </SparkLineChart>
-            </>
-            : <>
-            {/* 📉 */}
-            </>
+            isPendingSparklineData
+            // Show nothing while loading
+            ? null
+            : (
+              // If special Sparkline Data is available, use this
+              !isNullish(binnedSparklineData)
+              ? (
+                <SparkLineChart
+                  //data={item.sparklineData.data} // all data
+                  data={binnedSparklineData.data} // last 10 years
+                  height={100}
+                  area
+                  color={dynamicWarningColor}
+                  curve="linear"
+                  showHighlight
+                  showTooltip
+                  valueFormatter={(value: number | null) => (
+                    isNullish(value)
+                    ? `N/A`
+                    : (
+                      !isNullish(TopMetric2ValueVerb[metric])
+                      ? TopMetric2ValueVerb[metric].replaceAll('{0}', `${value}`) 
+                      : `${value}`
+                    )
+                  )}
+                  xAxis={{
+                    scaleType: 'point',
+                    data: binnedSparklineData.xAxis,
+                    // No formatter needed, it's preformatted
+                    //valueFormatter: (value) => typeof value === 'number' ? formatTermCode(value) : value,
+                  }}
+                  yAxis={{
+                    // min: undefined,
+                    // max: undefined,
+                    min: binnedSparklineData.yAxis.min,
+                    max: (
+                      binnedSparklineData.yAxis.max <= 0
+                      ? undefined
+                      : binnedSparklineData.yAxis.max
+                    ),
+                    // min: item.href.startsWith('/c/') ? item.sparklineData.yAxis.min : undefined,
+                    // max: item.href.startsWith('/c/') ? item.sparklineData.yAxis.max : undefined,
+                  }}
+                  sx={{
+                    maxWidth: '150px',
+                    [`& .${areaElementClasses.root}`]: {
+                      fill: `url(#sparkline-area-gradient)`,
+                    },
+                  }}
+                  >
+                  <AreaGradient id="sparkline-area-gradient" color={dynamicWarningColor} />
+                </SparkLineChart>
+              )
+              // Otherwise, used baked in Enrollment sparkline
+              : (
+                item.sparklineData !== undefined
+                ? (
+                  <>
+                  <SparkLineChart
+                    //data={item.sparklineData.data} // all data
+                    data={arrayLastEntries(item.sparklineData.data, 3 * 10)} // last 10 years
+                    height={100}
+                    area
+                    color={dynamicPrimaryColor}
+                    curve="linear"
+                    showHighlight
+                    showTooltip
+                    valueFormatter={(value: number | null) => value === null ? `N/A` : `${value} enrolled`}
+                    xAxis={{
+                      scaleType: 'point',
+                      //data: item.sparklineData.xAxis, // all data
+                      data: arrayLastEntries(item.sparklineData.xAxis, 3 * 10), // last 10 years
+                      valueFormatter: (value) => typeof value === 'number' ? formatTermCode(value) : value,
+                    }}
+                    yAxis={{
+                      // min: undefined,
+                      // max: undefined,
+                      min: item.sparklineData.yAxis.min,
+                      max: item.sparklineData.yAxis.max,
+                      // min: item.href.startsWith('/c/') ? item.sparklineData.yAxis.min : undefined,
+                      // max: item.href.startsWith('/c/') ? item.sparklineData.yAxis.max : undefined,
+                    }}
+                    sx={{
+                      maxWidth: '150px',
+                      [`& .${areaElementClasses.root}`]: {
+                        fill: `url(#sparkline-area-gradient)`,
+                      },
+                    }}
+                    >
+                    <AreaGradient id="sparkline-area-gradient" color={dynamicPrimaryColor} />
+                  </SparkLineChart>
+                  </>
+                )
+                : null
+              )
+            )
           }
         </div>
       </ListItemButton>

--- a/src/apps/web/src/components/TopListItem.tsx
+++ b/src/apps/web/src/components/TopListItem.tsx
@@ -1,3 +1,4 @@
+import { useEffect, type ComponentProps, type Ref } from 'react';
 import z from 'zod'
 import { Link } from '@tanstack/react-router'
 import { useTheme } from '@mui/material/styles'
@@ -13,17 +14,16 @@ import { Badge } from './badge'
 import { arrayLastEntries, formatTermCode } from '@cougargrades/models';
 import { TopMetric, type TopOptions, type TopResult, type TopTopic } from '@cougargrades/models/dto';
 import { is } from '@cougargrades/utils/zod';
+import { isNullish } from '@cougargrades/utils/nullish';
+import { useTopSparkline } from '../lib/services/useTopSparkline';
 
 
 import styles from './TopListItem.module.scss'
 //import interactivity from '../../styles/interactivity.module.scss'
 import instructorCardStyles from './instructorcard.module.scss'
-import { useTopSparkline } from '../lib/services/useTopSparkline';
-import { useEffect } from 'react';
-import { isNullish } from '@cougargrades/utils/nullish';
 
 
-interface TopListItemProps {
+interface TopListItemProps extends ComponentProps<'a'> {
   data: TopResult;
   index: number;
   options: Pick<TopOptions, 'metric' | 'time' | 'topic'>,
@@ -47,7 +47,7 @@ const TopMetric2ValueVerb: Record<TopMetric, string> = {
   'pageView': `{0} views`
 }
 
-export function TopListItem({ data: item, index, options, hidePosition, grow }: TopListItemProps) {
+export function TopListItem({ data: item, index, options, hidePosition, grow, ...props }: TopListItemProps) {
   const { metric, time, topic } = options;
   const theme = useTheme();
   // This is used because it looks prettier with the transparency and draws less attention to it
@@ -68,7 +68,7 @@ export function TopListItem({ data: item, index, options, hidePosition, grow }: 
   // }, [binnedSparklineData]);
 
   return (
-    <Link to={item.href} className="nostyle" style={{ height: grow ? '100%' : undefined }}>
+    <Link to={item.href} className="nostyle" style={{ height: grow ? '100%' : undefined }} {...props}>
       <ListItemButton alignItems="flex-start">
         <ListItemIcon className={styles.topItemIcon}>
           <Typography variant="h5" color="primary" sx={{ paddingTop: 0 }} data-value={index + 1}>

--- a/src/apps/web/src/components/TopListItem.tsx
+++ b/src/apps/web/src/components/TopListItem.tsx
@@ -28,6 +28,7 @@ interface TopListItemProps {
   index: number;
   options: Pick<TopOptions, 'metric' | 'time' | 'topic'>,
   hidePosition?: boolean;
+  grow?: boolean;
 }
 
 export function AreaGradient({ id, color, opacity }: { id: string, color: string, opacity?: [number, number] }) {
@@ -46,7 +47,7 @@ const TopMetric2ValueVerb: Record<TopMetric, string> = {
   'pageView': `{0} views`
 }
 
-export function TopListItem({ data: item, index, options, hidePosition }: TopListItemProps) {
+export function TopListItem({ data: item, index, options, hidePosition, grow }: TopListItemProps) {
   const { metric, time, topic } = options;
   const theme = useTheme();
   // This is used because it looks prettier with the transparency and draws less attention to it
@@ -59,14 +60,15 @@ export function TopListItem({ data: item, index, options, hidePosition }: TopLis
     'pageView': dynamicWarningColor,
   }
 
-  const { data: binnedSparklineData, isPending: isPendingSparklineData } = useTopSparkline(item.id, options);
+  const dynamicSparklineEnabled = options.metric !== 'totalEnrolled'
+  const { data: binnedSparklineData, isPending: isPendingSparklineData } = useTopSparkline(item.id, {...options, enabled: dynamicSparklineEnabled });
 
   // useEffect(() => {
   //   console.log('binnedSparklineData?', binnedSparklineData);
   // }, [binnedSparklineData]);
 
   return (
-    <Link to={item.href} className="nostyle">
+    <Link to={item.href} className="nostyle" style={{ height: grow ? '100%' : undefined }}>
       <ListItemButton alignItems="flex-start">
         <ListItemIcon className={styles.topItemIcon}>
           <Typography variant="h5" color="primary" sx={{ paddingTop: 0 }} data-value={index + 1}>
@@ -121,7 +123,7 @@ export function TopListItem({ data: item, index, options, hidePosition }: TopLis
             {item.metricFormatted}{ metric === 'totalEnrolled' ? <span className={styles.hintedMetricExtended}>{' '}since {item.metricTimeSpanFormatted}</span> : null}
           </Typography>
           {
-            isPendingSparklineData
+            isPendingSparklineData && dynamicSparklineEnabled
             // Show nothing while loading
             ? null
             : (

--- a/src/apps/web/src/components/search.tsx
+++ b/src/apps/web/src/components/search.tsx
@@ -59,12 +59,12 @@ export default function SearchBar() {
   // Used for displaying rerouting progress bar
   useEffect(() => {
     const handleStart = () => {
-      console.time('reroute')
+      //console.time('reroute')
       NProgress.start()
     }
     const handleStop = () => {
       NProgress.done()
-      console.timeEnd('reroute')
+      //console.timeEnd('reroute')
     }
 
     const unsubBeforeNavigate = router.subscribe('onBeforeNavigate', handleStart);

--- a/src/apps/web/src/lib/services/useLatestTerm.ts
+++ b/src/apps/web/src/lib/services/useLatestTerm.ts
@@ -1,7 +1,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { LatestTermService } from '@cougargrades/services'
-import { formatTermCode, getYear, SeasonCode, seasonCode } from '@cougargrades/models';
+import { END_OF_SEASON_DATES, formatTermCode, getYear, SeasonCode, seasonCode } from '@cougargrades/models';
 import type { Observable } from './Observable'
 import mailtoLink from 'mailto-link'
 
@@ -27,12 +27,6 @@ export function useLatestTerm() {
     } satisfies LatestTermResult) 
   })
   return query;
-}
-
-const END_OF_SEASON_DATES: Record<SeasonCode, `${number}-${number}`> = {
-  '01': '05-12', // Deadline for faculty to post Spring grade data (May 12)
-  '02': '08-19', // Deadline for faculty to post Summer grade data (August 19)
-  '03': '12-16', // Deadline for faculty to post Fall grade data (December 16)
 }
 
 export interface MissingTerm {

--- a/src/apps/web/src/lib/services/useTopResults.ts
+++ b/src/apps/web/src/lib/services/useTopResults.ts
@@ -1,5 +1,5 @@
 
-import { queryOptions, useQuery } from '@tanstack/react-query'
+import { queryOptions, useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import { TopService } from '@cougargrades/services'
 import { sortObjectByKeys } from '@cougargrades/utils/object'
 import type { TopOptions } from '../../../../../packages/models/src/dto/TopDto';
@@ -30,4 +30,41 @@ export function useTopResults(options: TopOptions) {
   const opts = topResultsQueryOptions(options);
   const query = useQuery(opts)
   return query;
+}
+
+export function useTopResultsInfinite(options: Omit<TopOptions, 'skip' | 'limit'> & { chunkSize?: number }) {
+  // Turns `options` into a unique query key that should be the same, regardless of key order
+  const queryKey = new URLSearchParams(
+    Object.entries(sortObjectByKeys(options))
+      .map(([key, value]) => ([key, `${value}` ]))
+  ).toString()
+
+
+  // return useInfiniteQuery(
+  //   ['top', queryKey],
+  //   // ({ pageParam = 0 }) =>
+  //   //   fetchTopPage({ ...options, skip: pageParam, limit: options.limit }),
+  //   // {
+  //   //   getNextPageParam: (lastPage, allPages) => {
+  //   //     if (lastPage.length < options.limit) return undefined; // no more
+  //   //     return allPages.reduce((sum, p) => sum + p.length, 0);
+  //   //   },
+  //   // },
+  // );
+
+  const chunkSize = options.chunkSize ?? 25;
+
+  return useInfiniteQuery({
+    queryKey: ['top', queryKey],
+    queryFn: async ({ pageParam }) => {
+      const svc = new TopService();
+      return await svc.GetTopResults({
+        ...options,
+        limit: chunkSize,
+        skip: pageParam,
+      })
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, pages, lastPageParam) => lastPageParam + chunkSize,
+  })
 }

--- a/src/apps/web/src/lib/services/useTopSparkline.ts
+++ b/src/apps/web/src/lib/services/useTopSparkline.ts
@@ -4,29 +4,26 @@ import { TopService } from '@cougargrades/services'
 import { sortObjectByKeys } from '@cougargrades/utils/object'
 import type { TopOptions } from '../../../../../packages/models/src/dto/TopDto';
 
-export function topTopicSparklineQueryOptions(itemName: string, options: Pick<TopOptions, 'metric' | 'time' | 'topic'>) {
-  // Turns `options` into a unique query key that should be the same, regardless of key order
-  const queryKey = new URLSearchParams(
-    Object.entries(sortObjectByKeys(options))
-      .map(([key, value]) => ([key, `${value}` ]))
-  ).toString()
-
-  return queryOptions({
-    queryKey: ['top', 'sparkline', itemName, queryKey],
-    queryFn: async () => {
-      const svc = new TopService();
-      return await svc.GetTopicSparkline(itemName, options)
-    },
-  })
-}
 
 /**
  * Query around `/api/top/sparkline/{topic}/{itemName}`
  * @param limit 
  * @returns 
  */
-export function useTopSparkline(itemName: string, options: Pick<TopOptions, 'metric' | 'time' | 'topic'>) {
-  const opts = topTopicSparklineQueryOptions(itemName, options);
-  const query = useQuery(opts)
+export function useTopSparkline(itemName: string, options: Pick<TopOptions, 'metric' | 'time' | 'topic'> & { enabled?: boolean }) {
+  // Turns `options` into a unique query key that should be the same, regardless of key order
+  const queryKey = new URLSearchParams(
+    Object.entries(sortObjectByKeys(options))
+      .map(([key, value]) => ([key, `${value}` ]))
+  ).toString()
+
+  const query = useQuery({
+    queryKey: ['top', 'sparkline', itemName, queryKey],
+    enabled: options.enabled,
+    queryFn: async () => {
+      const svc = new TopService();
+      return await svc.GetTopicSparkline(itemName, options)
+    },
+  })
   return query;
 }

--- a/src/apps/web/src/lib/services/useTopSparkline.ts
+++ b/src/apps/web/src/lib/services/useTopSparkline.ts
@@ -1,0 +1,32 @@
+
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import { TopService } from '@cougargrades/services'
+import { sortObjectByKeys } from '@cougargrades/utils/object'
+import type { TopOptions } from '../../../../../packages/models/src/dto/TopDto';
+
+export function topTopicSparklineQueryOptions(itemName: string, options: Pick<TopOptions, 'metric' | 'time' | 'topic'>) {
+  // Turns `options` into a unique query key that should be the same, regardless of key order
+  const queryKey = new URLSearchParams(
+    Object.entries(sortObjectByKeys(options))
+      .map(([key, value]) => ([key, `${value}` ]))
+  ).toString()
+
+  return queryOptions({
+    queryKey: ['top', 'sparkline', itemName, queryKey],
+    queryFn: async () => {
+      const svc = new TopService();
+      return await svc.GetTopicSparkline(itemName, options)
+    },
+  })
+}
+
+/**
+ * Query around `/api/top/sparkline/{topic}/{itemName}`
+ * @param limit 
+ * @returns 
+ */
+export function useTopSparkline(itemName: string, options: Pick<TopOptions, 'metric' | 'time' | 'topic'>) {
+  const opts = topTopicSparklineQueryOptions(itemName, options);
+  const query = useQuery(opts)
+  return query;
+}

--- a/src/apps/web/src/lib/top.ts
+++ b/src/apps/web/src/lib/top.ts
@@ -12,7 +12,7 @@ export const POPULAR_TABS: FaqPostData[] = [
     id: 2,
     slug: 'viewed-courses',
     title: 'Most Viewed Courses',
-    content: 'The Courses which are most often viewed on CougarGrades. These results are powered by Google Analytics, so please interpret the results with a grain of salt.',
+    content: 'The Courses which are most often viewed on CougarGrades. Before CougarGrades 2.0.0 (March 3rd 2026), these results were powered by Google Analytics. Any data recorded from before then may be inconsistent.',
   },
   {
     id: 3,
@@ -24,6 +24,6 @@ export const POPULAR_TABS: FaqPostData[] = [
     id: 4,
     slug: 'viewed-instructors',
     title: 'Most Viewed Instructors',
-    content: 'The Instructors which are most often viewed on CougarGrades. These results are powered by Google Analytics, so please interpret the results with a grain of salt.',
+    content: 'The Instructors which are most often viewed on CougarGrades. Before CougarGrades 2.0.0 (March 3rd 2026), these results were powered by Google Analytics. Any data recorded from before then may be inconsistent.',
   },
 ];

--- a/src/apps/web/src/main.tsx
+++ b/src/apps/web/src/main.tsx
@@ -16,6 +16,7 @@ import { routeTree } from './routeTree.gen'
 
 // Create a new router instance
 const router = createRouter({
+  defaultPreload: 'intent',
   routeTree,
   // Optionally provide your loaderClient to the router context for
   // convenience (you can provide anything you want to the router

--- a/src/apps/web/src/routes/top/$slug.tsx
+++ b/src/apps/web/src/routes/top/$slug.tsx
@@ -75,7 +75,9 @@ function RouteComponent() {
 
   // const { data, status, error } = useTopResults({ metric: viewMetric, topic: viewTopic, limit: viewLimit, skip: 0, time: viewTime, hideCore: hideCore });
 
-  const { data, status, hasNextPage, isFetchingNextPage, fetchNextPage } = useTopResultsInfinite({ metric: viewMetric, topic: viewTopic, time: viewTime, hideCore: hideCore, chunkSize: 100 })
+  const chunkSize = 25;
+
+  const { data, status, hasNextPage, isFetchingNextPage, fetchNextPage, isPending } = useTopResultsInfinite({ metric: viewMetric, topic: viewTopic, time: viewTime, hideCore: hideCore, chunkSize: chunkSize })
   const allRows = data?.pages.flat() ?? [];
 
   const parentRef = useRef<HTMLDivElement>(null);
@@ -95,7 +97,7 @@ function RouteComponent() {
       return
     }
 
-    const rowsLeftBeforeFetching = 10;
+    const rowsLeftBeforeFetching = Math.floor(chunkSize / 2);
 
     if (lastItem.index >= (allRows.length - 1 - rowsLeftBeforeFetching) && hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
@@ -154,6 +156,15 @@ function RouteComponent() {
             </Tooltip>
           </FormControl>
         </Box>
+        {
+          isPending
+          ? (
+            <Typography variant="subtitle2" color="text.disabled" style={{ fontStyle: 'italic' }}>
+              Loading ...
+            </Typography>
+          )
+          : null
+        }
         <div ref={parentRef}>
           <List sx={{
             width: '100%',
@@ -173,14 +184,14 @@ function RouteComponent() {
                       top: 0,
                       left: 0,
                       width: '100%',
-                      height: `${virtualRow.size}px`,
+                      //height: `${virtualRow.size}px`,
                       transform: `translateY(${virtualRow.start - rowVirtualizer.options.scrollMargin}px)`,
                     }}
                   >
                     {
                       isLoaderRow
                       ? (
-                        <Typography variant="subtitle2" color="text.secondary" style={{ fontStyle: 'italic' }}>
+                        <Typography variant="subtitle2" color="text.disabled" style={{ fontStyle: 'italic' }}>
                           { hasNextPage ? 'Loading more...' : 'Nothing more to load' }
                         </Typography>
                       )
@@ -189,6 +200,7 @@ function RouteComponent() {
                         <TopListItem data={item}
                           index={virtualRow.index}
                           options={{ metric: viewMetric, time: viewTime, topic: viewTopic }}
+                          ref={rowVirtualizer.measureElement}
                           grow
                         />
                         <Divider variant="inset" component="li" />

--- a/src/apps/web/src/routes/top/$slug.tsx
+++ b/src/apps/web/src/routes/top/$slug.tsx
@@ -46,7 +46,7 @@ export const Route = createFileRoute('/top/$slug')({
     //ctx.context.queryClient.ensureQueryData();
   },
   validateSearch: z.object({
-    viewLimit: z.coerce.number().default(10),
+    //viewLimit: z.coerce.number().default(10),
     viewTime: z.enum(['all', 'lastMonth', 'lastYear']).default('all'),
     //hideCore: z.stringbool().optional().default(false),
     hideCore: z.coerce.boolean().default(false),
@@ -59,14 +59,14 @@ function RouteComponent() {
   const { slug } = Route.useParams();
   const { post, allPosts } = getPostData(slug);
   const searchParams = Route.useSearch();
-  const { viewLimit, viewTime, hideCore } = searchParams
+  const { viewTime, hideCore } = searchParams
   
   // Example updating search params:
   // 
   const navigate = useNavigate({ from: Route.fullPath })
 
   const setSearchParams = (opt: Partial<typeof searchParams>) => navigate({ search: (prev) => ({ ...prev, ...opt }), replace: true, resetScroll: false })
-  const setViewLimit = (x: number) => setSearchParams({ viewLimit: x })
+  // const setViewLimit = (x: number) => setSearchParams({ viewLimit: x })
   const setViewTime = (x: TopTime) => setSearchParams({ viewTime: x })
   const setHideCore = (x: boolean) => setSearchParams({  hideCore: x });
 
@@ -125,6 +125,7 @@ function RouteComponent() {
           {post?.content ?? '(Unknown)'}
         </Typography>
         <Box className={styles.controlBox}>
+          {/*  
           <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
             <InputLabel>Count</InputLabel>
             <Select label="Count" value={viewLimit} onChange={(e) => setViewLimit(e.target.value)}>
@@ -135,6 +136,7 @@ function RouteComponent() {
               <MenuItem value={250}>Top 250</MenuItem>
             </Select>
           </FormControl>
+          */}
           <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
             <InputLabel>Time Span</InputLabel>
             <Select label="Time Span" value={viewTime} onChange={(e) => setViewTime(e.target.value as any)}>

--- a/src/apps/web/src/routes/top/$slug.tsx
+++ b/src/apps/web/src/routes/top/$slug.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { createFileRoute, notFound, useNavigate, useRouter } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
+import { useVirtualizer, useWindowVirtualizer } from '@tanstack/react-virtual'
 import { z } from 'zod'
 import type { TopMetric, TopTime, TopTopic } from '@cougargrades/models/dto';
 import { isNullish } from '@cougargrades/utils/nullish';
 import { Box, Container, Divider, FormControl, FormControlLabel, InputLabel, List, MenuItem, Select, Switch, Tooltip, Typography } from '@mui/material'
 
-import { useTopResults } from '../../lib/services/useTopResults';
+import { useTopResults, useTopResultsInfinite } from '../../lib/services/useTopResults';
 import { POPULAR_TABS } from '../../lib/top';
 import { PankoRow } from '../../components/panko';
 import { ErrorBoxIndeterminate, LoadingBoxIndeterminate } from '../../components/loading';
@@ -72,10 +73,35 @@ function RouteComponent() {
   const viewMetric: TopMetric = slug.includes('viewed') ? 'pageView' : 'totalEnrolled'
   const viewTopic: TopTopic = slug.includes('instructor') ? 'instructor' : 'course'
 
-  const { data, status, error } = useTopResults({ metric: viewMetric, topic: viewTopic, limit: viewLimit, skip: 0, time: viewTime, hideCore: hideCore });
+  // const { data, status, error } = useTopResults({ metric: viewMetric, topic: viewTopic, limit: viewLimit, skip: 0, time: viewTime, hideCore: hideCore });
+
+  const { data, status, hasNextPage, isFetchingNextPage, fetchNextPage } = useTopResultsInfinite({ metric: viewMetric, topic: viewTopic, time: viewTime, hideCore: hideCore, chunkSize: 100 })
+  const allRows = data?.pages.flat() ?? [];
+
+  const parentRef = useRef<HTMLDivElement>(null);
+  const rowVirtualizer = useWindowVirtualizer({
+    count: hasNextPage ? allRows.length + 1 : allRows.length,
+    //getScrollElement: () => parentRef.current,
+    estimateSize: () => 150,
+    overscan: 5,
+    scrollMargin: parentRef.current?.offsetTop ?? 0,
+  })
   
-  //router.preloadRoute()
-  
+  // Keep loading
+  useEffect(() => {
+    const [lastItem] = [...rowVirtualizer.getVirtualItems()].reverse();
+
+    if (!lastItem) {
+      return
+    }
+
+    const rowsLeftBeforeFetching = 10;
+
+    if (lastItem.index >= (allRows.length - 1 - rowsLeftBeforeFetching) && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, fetchNextPage, allRows.length, isFetchingNextPage, rowVirtualizer.getVirtualItems()]);
+
   
   return (
     <>
@@ -128,40 +154,85 @@ function RouteComponent() {
             </Tooltip>
           </FormControl>
         </Box>
-        <List sx={{ width: '100%' }}>
-          {
-            status === 'success' && Array.isArray(data)
-            ? (
-              <>
-              {
-                data
-                .map((item, index, array) => (
-                  <React.Fragment key={item.key}>
-                    <TopListItem data={item} index={index} options={{ metric: viewMetric, time: viewTime, topic: viewTopic }} />
-                    { index < (array.length - 1) ? <Divider variant="inset" component="li" /> : null }
-                  </React.Fragment>
-                ))
-              }
-              {
-                data.length === 0
-                ? (
-                  <Typography sx={{ textAlign: 'center' }} variant="body2" color="text.secondary">
-                    There are no results with the current filters. You may need to expand the Count to a larger number.
-                  </Typography>
+        <div ref={parentRef}>
+          <List sx={{
+            width: '100%',
+            height: `${rowVirtualizer.getTotalSize()}px`,
+            position: 'relative',
+          }}
+          >
+            {
+              rowVirtualizer.getVirtualItems().map(virtualRow => {
+                const isLoaderRow = virtualRow.index > allRows.length - 1;
+                const item = allRows[virtualRow.index];
+
+                return (
+                  <div key={virtualRow.index}
+                    style={{
+                      position: 'absolute',
+                      top: 0,
+                      left: 0,
+                      width: '100%',
+                      height: `${virtualRow.size}px`,
+                      transform: `translateY(${virtualRow.start - rowVirtualizer.options.scrollMargin}px)`,
+                    }}
+                  >
+                    {
+                      isLoaderRow
+                      ? (
+                        <Typography variant="subtitle2" color="text.secondary" style={{ fontStyle: 'italic' }}>
+                          { hasNextPage ? 'Loading more...' : 'Nothing more to load' }
+                        </Typography>
+                      )
+                      : (
+                        <>
+                        <TopListItem data={item}
+                          index={virtualRow.index}
+                          options={{ metric: viewMetric, time: viewTime, topic: viewTopic }}
+                          grow
+                        />
+                        <Divider variant="inset" component="li" />
+                        </>
+                      )
+                    }
+                  </div>
                 )
-                : null
-              }
-              </>
-            )
-            : status === 'pending' 
-            ? (
-              <LoadingBoxIndeterminate title="Loading..." />
-            )
-            : (
-              <ErrorBoxIndeterminate />
-            )
-          }
-        </List>
+              })
+            }
+            {/* {
+              status === 'success' && Array.isArray(data)
+              ? (
+                <>
+                {
+                  data
+                  .map((item, index, array) => (
+                    <React.Fragment key={item.key}>
+                      <TopListItem data={item} index={index} options={{ metric: viewMetric, time: viewTime, topic: viewTopic }} />
+                      { index < (array.length - 1) ? <Divider variant="inset" component="li" /> : null }
+                    </React.Fragment>
+                  ))
+                }
+                {
+                  data.length === 0
+                  ? (
+                    <Typography sx={{ textAlign: 'center' }} variant="body2" color="text.secondary">
+                      There are no results with the current filters. You may need to expand the Count to a larger number.
+                    </Typography>
+                  )
+                  : null
+                }
+                </>
+              )
+              : status === 'pending' 
+              ? (
+                <LoadingBoxIndeterminate title="Loading..." />
+              )
+              : (
+                <ErrorBoxIndeterminate />
+              )
+            } */}
+          </List>
+        </div>
       </div>
     </SidebarContainer>
     </>

--- a/src/apps/web/src/routes/top/$slug.tsx
+++ b/src/apps/web/src/routes/top/$slug.tsx
@@ -72,7 +72,7 @@ function RouteComponent() {
   const viewMetric: TopMetric = slug.includes('viewed') ? 'pageView' : 'totalEnrolled'
   const viewTopic: TopTopic = slug.includes('instructor') ? 'instructor' : 'course'
 
-  const { data, status, error } = useTopResults({ metric: viewMetric, topic: viewTopic, limit: viewLimit, time: viewTime, hideCore: hideCore });
+  const { data, status, error } = useTopResults({ metric: viewMetric, topic: viewTopic, limit: viewLimit, skip: 0, time: viewTime, hideCore: hideCore });
   
   //router.preloadRoute()
   
@@ -105,7 +105,6 @@ function RouteComponent() {
               <MenuItem value={50}>Top 50</MenuItem>
               <MenuItem value={100}>Top 100</MenuItem>
               <MenuItem value={250}>Top 250</MenuItem>
-              <MenuItem value={500}>Top 500</MenuItem>
             </Select>
           </FormControl>
           <FormControl sx={{ m: 1, minWidth: 120 }} size="small">

--- a/src/apps/web/src/routes/top/$slug.tsx
+++ b/src/apps/web/src/routes/top/$slug.tsx
@@ -137,7 +137,7 @@ function RouteComponent() {
                 data
                 .map((item, index, array) => (
                   <React.Fragment key={item.key}>
-                    <TopListItem data={item} index={index} viewMetric={viewMetric} />
+                    <TopListItem data={item} index={index} options={{ metric: viewMetric, time: viewTime, topic: viewTopic }} />
                     { index < (array.length - 1) ? <Divider variant="inset" component="li" /> : null }
                   </React.Fragment>
                 ))

--- a/src/apps/web/src/routes/top/$slug.tsx
+++ b/src/apps/web/src/routes/top/$slug.tsx
@@ -105,6 +105,7 @@ function RouteComponent() {
               <MenuItem value={50}>Top 50</MenuItem>
               <MenuItem value={100}>Top 100</MenuItem>
               <MenuItem value={250}>Top 250</MenuItem>
+              <MenuItem value={500}>Top 500</MenuItem>
             </Select>
           </FormControl>
           <FormControl sx={{ m: 1, minWidth: 120 }} size="small">

--- a/src/packages/models/src/PopCon.ts
+++ b/src/packages/models/src/PopCon.ts
@@ -63,22 +63,6 @@ export const PopConOptions = z.object({
   exclude: z.array(z.string()).optional(),
 })
 
-export function EpochSecondsToTemporal(epoch_seconds: number | bigint): Temporal.ZonedDateTime {
-  if (typeof epoch_seconds === 'number') {
-    return Temporal.Instant.fromEpochMilliseconds(epoch_seconds * 1000).toZonedDateTimeISO(Temporal.Now.timeZoneId())
-  }
-  else {
-    return Temporal.Instant.fromEpochNanoseconds(epoch_seconds * 1000n * 1000000n).toZonedDateTimeISO(Temporal.Now.timeZoneId());
-  }
-}
-
-export function ToEpochSeconds(instant: Temporal.Instant | Temporal.ZonedDateTime | Date): number {
-  if (instant instanceof Temporal.Instant || instant instanceof Temporal.ZonedDateTime) {
-    return Math.round(instant.epochMilliseconds / 1000);
-  }
-  return Math.round(instant.valueOf() / 1000);
-}
-
 const pathnamePattern = new URLPattern({ pathname: `/:tlp/:primaryKey`});
 const Tlp2DocumentCollection = new Map<'c' | 'i' | 'g', 'catalog' | 'instructors' | 'groups'>([
   ['c', 'catalog'],

--- a/src/packages/models/src/SparklineData.ts
+++ b/src/packages/models/src/SparklineData.ts
@@ -24,3 +24,24 @@ export const SparklineData = z.object({
     median: z.number(),
   })
 });
+
+export type BinnedSparklineData = z.infer<typeof BinnedSparklineData>;
+export const BinnedSparklineData = SparklineData.extend({
+  /**
+   * Each point represents a time range
+   */
+  xAxis: z.string().array(),
+  /**
+   * This is the range (set of possible y-values).
+   * This is different depending on the data.
+   * For courses, the upper range is the max value that a course had enrollment in a single semester.
+   * For instructors, the upper range is the max value that a instructors had enrollment in a single semester.
+   * The lower range for both is (presumably) zero.
+   */
+  yAxis: z.object({
+    // Typically, 0
+    min: z.number(),
+    // Depends on what is being measured
+    max: z.number(),
+  })
+})

--- a/src/packages/models/src/TermCode.ts
+++ b/src/packages/models/src/TermCode.ts
@@ -39,3 +39,23 @@ export function parseTermStringAsTermCode(termString: string): number {
   return parseInt(`${yearStr}${seasonStr2SeasonCode.get(seasonStr.toLowerCase().trim())}`)
   //return parseInt(`${termString.split(' ')[1]}${seasonCodes.get(termString.split(' ')[0])}`);
 }
+
+export const END_OF_SEASON_DATES: Record<SeasonCode, `${number}-${number}`> = {
+  '01': '05-12', // Deadline for faculty to post Spring grade data (May 12)
+  '02': '08-19', // Deadline for faculty to post Summer grade data (August 19)
+  '03': '12-16', // Deadline for faculty to post Fall grade data (December 16)
+}
+
+export function getCurrentSeason(date = new Date()): SeasonCode {
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const monthDay = `${month}-${day}`;
+
+  // Return the first season whose end date is >= today
+  for (const [code, endDate] of Object.entries(END_OF_SEASON_DATES)) {
+    if (monthDay <= endDate) return code as SeasonCode;
+  }
+
+  // We're past all end dates (after Dec 16) — wrap around to Spring of next year
+  return '01';
+}

--- a/src/packages/models/src/dto/TopDto.ts
+++ b/src/packages/models/src/dto/TopDto.ts
@@ -28,7 +28,7 @@ export type TopOptions = z.infer<typeof TopOptions>
 export const TopOptions = z.object({
   metric: TopMetric,
   topic: TopTopic,
-  limit: z.coerce.number().int().min(1).max(250),
+  limit: z.coerce.number().int().min(1).max(500),
   time: TopTime,
   hideCore: z.stringbool().optional().default(false),
 })

--- a/src/packages/models/src/dto/TopDto.ts
+++ b/src/packages/models/src/dto/TopDto.ts
@@ -28,7 +28,8 @@ export type TopOptions = z.infer<typeof TopOptions>
 export const TopOptions = z.object({
   metric: TopMetric,
   topic: TopTopic,
-  limit: z.coerce.number().int().min(1).max(500),
+  limit: z.coerce.number().int().min(1).max(250),
+  skip: z.coerce.number().int().min(0).optional().default(0),
   time: TopTime,
   hideCore: z.stringbool().optional().default(false),
 })

--- a/src/packages/models/src/dto/TopDto.ts
+++ b/src/packages/models/src/dto/TopDto.ts
@@ -17,6 +17,13 @@ export const TopTime2Duration = new Map<TopTime, Temporal.Duration>([
   ['lastYear', Temporal.Duration.from({ days: 365 })]
 ])
 
+export const TopTime2BinSize = new Map<TopTime, Temporal.Duration>([
+  // use "quarters" (1/4th of the year)
+  ['all', Temporal.Duration.from({ months: 12/4 })],
+  ['lastMonth', Temporal.Duration.from({ days: 1 })],
+  ['lastYear', Temporal.Duration.from({ weeks: 1 })]
+])
+
 export type TopOptions = z.infer<typeof TopOptions>
 export const TopOptions = z.object({
   metric: TopMetric,

--- a/src/packages/models/src/dto/TopResult.ts
+++ b/src/packages/models/src/dto/TopResult.ts
@@ -1,7 +1,7 @@
 
 import { z } from 'zod'
 import { CourseInstructorResult } from './CourseInstructorResult'
-import { SparklineData } from '../SparklineData'
+import { BinnedSparklineData, SparklineData } from '../SparklineData'
 import { CoursePlusMetrics, InstructorPlusMetrics } from './Plus'
 import { course2Result } from './CourseResult'
 import { instructor2Result } from './InstructorResult'

--- a/src/packages/services/src/TopService.ts
+++ b/src/packages/services/src/TopService.ts
@@ -19,7 +19,7 @@ export class TopService extends BaseApiService {
   }
 
   public async GetInstructorRank(instructorName: string, { metric, time }: Pick<TopOptions, 'metric' | 'time'>): Promise<RankingResult | null> {
-    return await this.Get(`/api/top/rank/instructor/${encodeURIComponent(instructorName)}`, { metric, time }, RankingResult);
+    return await this.Get(`/api/top/rank/instructor/${encodeURIComponent(instructorName)}`, { metric, time }, RankingResult.nullable());
   }
 
   // public async GetCourseSparkline(courseName: string, { metric, time }: Pick<TopOptions, 'metric' | 'time'>): Promise<BinnedSparklineData | null> {
@@ -31,7 +31,7 @@ export class TopService extends BaseApiService {
   // }
 
   public async GetTopicSparkline(courseName: string, { metric, time, topic }: Pick<TopOptions, 'metric' | 'time' | 'topic'>): Promise<BinnedSparklineData | null> {
-    return await this.Get(`/api/top/sparkline/${topic}/${encodeURIComponent(courseName)}`, { metric, time }, BinnedSparklineData);
+    return await this.Get(`/api/top/sparkline/${topic}/${encodeURIComponent(courseName)}`, { metric, time }, BinnedSparklineData.nullable());
   }
 }
 

--- a/src/packages/services/src/TopService.ts
+++ b/src/packages/services/src/TopService.ts
@@ -10,8 +10,8 @@ export class TopService extends BaseApiService {
     super()
   }
 
-  public async GetTopResults({ metric, topic, limit, time, hideCore }: TopOptions): Promise<TopResult[]> {
-    return await this.Get(`/api/top`, { metric, topic, limit: limit.toString(), time, hideCore: `${hideCore}` }, TopResult.array()) ?? [];
+  public async GetTopResults({ metric, topic, limit, skip, time, hideCore }: TopOptions): Promise<TopResult[]> {
+    return await this.Get(`/api/top`, { metric, topic, limit: limit.toString(), skip: skip.toString(), time, hideCore: `${hideCore}` }, TopResult.array()) ?? [];
   }
 
   public async GetCourseRank(courseName: string, { metric, time }: Pick<TopOptions, 'metric' | 'time'>): Promise<RankingResult | null> {

--- a/src/packages/services/src/TopService.ts
+++ b/src/packages/services/src/TopService.ts
@@ -1,6 +1,7 @@
 
 import { z } from 'zod'
-import { TopOptions, TopResult } from '@cougargrades/models/dto'
+import { BinnedSparklineData } from '@cougargrades/models';
+import { RankingResult, TopOptions, TopResult } from '@cougargrades/models/dto'
 import { BaseApiService } from './private/BaseApiService'
 
 
@@ -11,6 +12,26 @@ export class TopService extends BaseApiService {
 
   public async GetTopResults({ metric, topic, limit, time, hideCore }: TopOptions): Promise<TopResult[]> {
     return await this.Get(`/api/top`, { metric, topic, limit: limit.toString(), time, hideCore: `${hideCore}` }, TopResult.array()) ?? [];
+  }
+
+  public async GetCourseRank(courseName: string, { metric, time }: Pick<TopOptions, 'metric' | 'time'>): Promise<RankingResult | null> {
+    return await this.Get(`/api/top/rank/course/${encodeURIComponent(courseName)}`, { metric, time }, RankingResult);
+  }
+
+  public async GetInstructorRank(instructorName: string, { metric, time }: Pick<TopOptions, 'metric' | 'time'>): Promise<RankingResult | null> {
+    return await this.Get(`/api/top/rank/instructor/${encodeURIComponent(instructorName)}`, { metric, time }, RankingResult);
+  }
+
+  // public async GetCourseSparkline(courseName: string, { metric, time }: Pick<TopOptions, 'metric' | 'time'>): Promise<BinnedSparklineData | null> {
+  //   return await this.Get(`/api/top/sparkline/course/${encodeURIComponent(courseName)}`, { metric, time }, BinnedSparklineData);
+  // }
+
+  // public async GetInstructorSparkline(instructorName: string, { metric, time }: Pick<TopOptions, 'metric' | 'time'>): Promise<BinnedSparklineData | null> {
+  //   return await this.Get(`/api/top/sparkline/instructor/${encodeURIComponent(instructorName)}`, { metric, time }, BinnedSparklineData);
+  // }
+
+  public async GetTopicSparkline(courseName: string, { metric, time, topic }: Pick<TopOptions, 'metric' | 'time' | 'topic'>): Promise<BinnedSparklineData | null> {
+    return await this.Get(`/api/top/sparkline/${topic}/${encodeURIComponent(courseName)}`, { metric, time }, BinnedSparklineData);
   }
 }
 

--- a/src/packages/services/src/environment.ts
+++ b/src/packages/services/src/environment.ts
@@ -29,7 +29,7 @@ const CF_PAGES_COMMIT_SHA = z.string().optional().parse(import.meta.env.VITE_CF_
  */
 const CF_PAGES_URL = z.string().optional().parse(import.meta.env.VITE_CF_PAGES_URL);
 const cfPreviewBranchPattern = new URLPattern(`https://:branch.:projectName.pages.dev/`);
-const PREVIEW_BRANCH_NAME = cfPreviewBranchPattern.exec(CF_PAGES_URL)?.hostname.groups['branch'];
+const PREVIEW_BRANCH_NAME = cfPreviewBranchPattern.exec(window.location.href)?.hostname.groups['branch'];
 
 
 //#endregion

--- a/src/packages/services/src/environment.ts
+++ b/src/packages/services/src/environment.ts
@@ -29,7 +29,7 @@ const CF_PAGES_COMMIT_SHA = z.string().optional().parse(import.meta.env.VITE_CF_
  */
 const CF_PAGES_URL = z.string().optional().parse(import.meta.env.VITE_CF_PAGES_URL);
 const cfPreviewBranchPattern = new URLPattern(`https://:branch.:projectName.pages.dev/`);
-const PREVIEW_BRANCH_NAME = cfPreviewBranchPattern.exec(window.location.href)?.hostname.groups['branch'];
+const PREVIEW_BRANCH_NAME = cfPreviewBranchPattern.exec(window.location.origin)?.hostname.groups['branch'];
 
 
 //#endregion

--- a/src/packages/services/src/environment.ts
+++ b/src/packages/services/src/environment.ts
@@ -1,6 +1,7 @@
 
 import { z } from 'zod'
 import { isNullishOrWhitespace } from '@cougargrades/utils/nullish'
+import { is } from '@cougargrades/utils/zod';
 
 //#region Cloudflare-specific
 
@@ -19,6 +20,17 @@ const CF_PAGES_BRANCH = z.string().optional().parse(import.meta.env.VITE_CF_PAGE
  * Ex: `f71a6dad94f6792a64fc9eb9d9ee728d48f2317c`
  */
 const CF_PAGES_COMMIT_SHA = z.string().optional().parse(import.meta.env.VITE_CF_PAGES_COMMIT_SHA);
+
+/**
+ * When built by Cloudflare, this will be specified: https://developers.cloudflare.com/pages/configuration/build-configuration/#environment-variables
+ * When built locally, it will be nothing.
+ * 
+ * Ex: https://feature-view-sparklines.web-22p.pages.dev/
+ */
+const CF_PAGES_URL = z.string().optional().parse(import.meta.env.VITE_CF_PAGES_URL);
+const cfPreviewBranchPattern = new URLPattern(`https://:branch.:projectName.pages.dev/`);
+const PREVIEW_BRANCH_NAME = cfPreviewBranchPattern.exec(CF_PAGES_URL)?.hostname.groups['branch'];
+
 
 //#endregion
 
@@ -63,6 +75,7 @@ export const ENVIRONMENT_NAME: EnvironmentName = (
   )
 );
 
+const PREVIEW_API_BASE = `https://{0}-cougargrades-api.themacphage.workers.dev/`;
 const DEFAULT_API_ORIGIN = new URL(`https://api.cougargrades.io`);
 const VITE_API_ORIGIN = z.url().optional().parse(import.meta.env.VITE_API_ORIGIN);
 
@@ -72,9 +85,16 @@ const VITE_API_ORIGIN = z.url().optional().parse(import.meta.env.VITE_API_ORIGIN
  * - otherwise, DEFAULT_API_ORIGIN
  */
 export const API_ORIGIN: URL = (
+  // If "VITE_API_ORIGIN" is specified, always use it
   !isNullishOrWhitespace(VITE_API_ORIGIN)
   ? new URL(VITE_API_ORIGIN)
-  : DEFAULT_API_ORIGIN
+  // Otherwiose
+  : (
+    // If a "preview branch" is detected and it makes a valid URL, then try that!
+    !isNullishOrWhitespace(PREVIEW_BRANCH_NAME) && is(PREVIEW_API_BASE.replace('{0}', PREVIEW_BRANCH_NAME), z.url())
+    ? new URL(PREVIEW_API_BASE.replace('{0}', PREVIEW_BRANCH_NAME))
+    : DEFAULT_API_ORIGIN
+  )
 );
 
 //#endregion

--- a/src/packages/utils/src/temporal.ts
+++ b/src/packages/utils/src/temporal.ts
@@ -9,3 +9,37 @@ export function GetTimeRangeFromDurationBeforeNow(endTime: Temporal.ZonedDateTim
     endTime
   ]
 }
+
+export function IsABeforeB(a: Temporal.ZonedDateTime, b: Temporal.ZonedDateTime): boolean {
+  return Temporal.ZonedDateTime.compare(a, b) < 0;
+}
+
+/**
+ * For the current time, get the "date_epoch_seconds" equivalent value
+ * @param instant 
+ * @returns 
+ */
+export function GetNowDateEpochSeconds(): Temporal.ZonedDateTime {
+  return Temporal.Now.instant().toZonedDateTimeISO(UTC_TIMEZONE_ID).startOfDay();
+}
+
+export function ToEpochSeconds(instant: Temporal.Instant | Temporal.ZonedDateTime | Date): number {
+  if (instant instanceof Temporal.Instant || instant instanceof Temporal.ZonedDateTime) {
+    return Math.trunc(instant.epochMilliseconds / 1000);
+  }
+  return Math.trunc(instant.valueOf() / 1000);
+}
+
+export function EpochSecondsToTemporal(epoch_seconds: number | bigint): Temporal.Instant {
+  if (typeof epoch_seconds === 'number') {
+    return Temporal.Instant.fromEpochMilliseconds(epoch_seconds * 1000);//.toZonedDateTimeISO(Temporal.Now.timeZoneId())
+  }
+  else {
+    return Temporal.Instant.fromEpochNanoseconds(epoch_seconds * 1000n * 1000000n);//.toZonedDateTimeISO(Temporal.Now.timeZoneId());
+  }
+}
+
+export function EpochSecondsToDate(epoch_seconds: number): Date {
+  return new Date(epoch_seconds * 1000);
+}
+

--- a/src/packages/vendor/package.json
+++ b/src/packages/vendor/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./classbrowser.uh.edu": "./src/classbrowser.uh.edu/_index.ts",
     "./cloudflare-turnstile": "./src/cloudflare/turnstile.ts",
     "./firestore": "./src/google/firestore.ts",
     "./google-analytics": "./src/google/analytics.ts",
@@ -16,14 +17,19 @@
     "@cougargrades/utils": "workspace:*",
     "@google-analytics/data": "^5.2.1",
     "@octokit/rest": "^22.0.1",
+    "lodash-es": "^4.17.23",
     "temporal-polyfill": "^0.3.0",
     "zod": "^4.1"
   },
   "devDependencies": {
-    "typescript": "^5"
+    "@types/lodash-es": "^4.17.12",
+    "typescript": "^5",
+    "vitest": "^4.0.18"
   },
   "scripts": {
     "build": "tsc",
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "test": "vitest --testNamePattern sections",
+    "test:debugger": "vitest --test-timeout=0 --no-file-parallelism"
   }
 }

--- a/src/packages/vendor/package.json
+++ b/src/packages/vendor/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "tsc",
     "tsc": "tsc",
-    "test": "vitest --testNamePattern sections",
+    "test": "vitest",
     "test:debugger": "vitest --test-timeout=0 --no-file-parallelism"
   }
 }

--- a/src/packages/vendor/src/classbrowser.uh.edu/UHClassBrowserService.ts
+++ b/src/packages/vendor/src/classbrowser.uh.edu/UHClassBrowserService.ts
@@ -1,0 +1,61 @@
+
+
+import { z } from 'zod'
+import { BaseApiService } from './private/BaseApiService'
+import { CourseInfo, ECareer, EInstructionMode, InstructionModeInfo, InstructorInfo, LiveSectionFilters, LiveSectionResponse, SubjectInfo, TermInfo } from './models'
+import { isNullish } from '@cougargrades/utils/nullish'
+
+export class UHClassBrowserService extends BaseApiService {
+  constructor() {
+    super()
+  }
+
+  public async GetAllTerms(): Promise<TermInfo[] | null> {
+    return await this.Get(`/api/terms`, undefined, TermInfo.array())
+  }
+
+  public async GetAllSubjects(): Promise<SubjectInfo[] | null> {
+    const schema = z.object({
+      data: SubjectInfo.array()
+    })
+    return (await this.Get(`/api/subjects`, undefined, schema))?.data ?? null;
+  }
+
+  public async GetAllInstructionModes(args?: { term?: string, career?: ECareer }): Promise<InstructionModeInfo[] | null> {
+    const schema = z.object({
+      data: InstructionModeInfo.array()
+    })
+    return (await this.Get(`/api/online/career/modes`, args, schema))?.data ?? null;
+  }
+
+  /**
+   * 
+   * @param startsWith Must be at least 1 character in length
+   * @returns 
+   */
+  public async SearchInstructors(startsWith: string): Promise<InstructorInfo[] | null> {
+    const schema = z.object({
+      data: InstructorInfo.array()
+    })
+    return (await this.Get(`/api/instructor`, { instructor: startsWith }, schema))?.data ?? null;
+  }
+
+  public async SearchCatalog(args?: { term?: string, subject?: string, mode?: EInstructionMode, career?: ECareer }): Promise<CourseInfo[] | null> {
+    const schema = z.object({
+      data: CourseInfo.array()
+    })
+    return (await this.Get(`/api/online/catalog`, args, schema))?.data ?? null;
+  }
+
+  public async SearchSections(args: Partial<LiveSectionFilters>): Promise<LiveSectionResponse | null> {
+    let body = new URLSearchParams();
+    for(let [k, v] of Object.entries(args)) {
+      if (!isNullish(v)) {
+        body.append(k, `${v}`);
+      }
+    }
+    return await this.Post(`/api/courses`, undefined, LiveSectionResponse, { body: body });
+  }
+}
+
+

--- a/src/packages/vendor/src/classbrowser.uh.edu/_index.ts
+++ b/src/packages/vendor/src/classbrowser.uh.edu/_index.ts
@@ -1,0 +1,3 @@
+
+export * from './models'
+export * from './UHClassBrowserService'

--- a/src/packages/vendor/src/classbrowser.uh.edu/bruno/GetAllSubjects.yml
+++ b/src/packages/vendor/src/classbrowser.uh.edu/bruno/GetAllSubjects.yml
@@ -1,0 +1,15 @@
+info:
+  name: GetAllSubjects
+  type: http
+  seq: 1
+
+http:
+  method: GET
+  url: "{{BASE}}/api/subjects"
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/packages/vendor/src/classbrowser.uh.edu/bruno/GetAllTerms.yml
+++ b/src/packages/vendor/src/classbrowser.uh.edu/bruno/GetAllTerms.yml
@@ -1,0 +1,15 @@
+info:
+  name: GetAllTerms
+  type: http
+  seq: 3
+
+http:
+  method: GET
+  url: "{{BASE}}/api/terms"
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/packages/vendor/src/classbrowser.uh.edu/bruno/GetCareersForTerm.yml
+++ b/src/packages/vendor/src/classbrowser.uh.edu/bruno/GetCareersForTerm.yml
@@ -1,0 +1,19 @@
+info:
+  name: GetCareersForTerm
+  type: http
+  seq: 7
+
+http:
+  method: GET
+  url: "{{BASE}}/api/online/term/career?term=2280"
+  params:
+    - name: term
+      value: "2280"
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/packages/vendor/src/classbrowser.uh.edu/bruno/GetInstructionModes.yml
+++ b/src/packages/vendor/src/classbrowser.uh.edu/bruno/GetInstructionModes.yml
@@ -1,0 +1,22 @@
+info:
+  name: GetInstructionModes
+  type: http
+  seq: 13
+
+http:
+  method: GET
+  url: "{{BASE}}/api/online/career/modes?term=2280&career=GRAD"
+  params:
+    - name: term
+      value: "2280"
+      type: query
+    - name: career
+      value: GRAD
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/packages/vendor/src/classbrowser.uh.edu/bruno/GetSessionsForTerm.yml
+++ b/src/packages/vendor/src/classbrowser.uh.edu/bruno/GetSessionsForTerm.yml
@@ -1,0 +1,19 @@
+info:
+  name: GetSessionsForTerm
+  type: http
+  seq: 5
+
+http:
+  method: GET
+  url: "{{BASE}}/api/online/sessions?term=2280"
+  params:
+    - name: term
+      value: "2280"
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/packages/vendor/src/classbrowser.uh.edu/bruno/GetSubjectsForTerm.yml
+++ b/src/packages/vendor/src/classbrowser.uh.edu/bruno/GetSubjectsForTerm.yml
@@ -1,0 +1,19 @@
+info:
+  name: GetSubjectsForTerm
+  type: http
+  seq: 6
+
+http:
+  method: GET
+  url: "{{BASE}}/api/online/term/subjects?term=2280"
+  params:
+    - name: term
+      value: "2280"
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/packages/vendor/src/classbrowser.uh.edu/bruno/SearchCatalog.yml
+++ b/src/packages/vendor/src/classbrowser.uh.edu/bruno/SearchCatalog.yml
@@ -1,0 +1,32 @@
+info:
+  name: SearchCatalog
+  type: http
+  seq: 17
+
+http:
+  method: GET
+  url: "{{BASE}}/api/online/catalog"
+  params:
+    - name: term
+      value: "2280"
+      type: query
+      disabled: true
+    - name: subject
+      value: ACCT
+      type: query
+      disabled: true
+    - name: mode
+      value: Face-to-Face
+      type: query
+      disabled: true
+    - name: career
+      value: GRAD
+      type: query
+      disabled: true
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/packages/vendor/src/classbrowser.uh.edu/bruno/SearchInstructors.yml
+++ b/src/packages/vendor/src/classbrowser.uh.edu/bruno/SearchInstructors.yml
@@ -1,0 +1,19 @@
+info:
+  name: SearchInstructors
+  type: http
+  seq: 21
+
+http:
+  method: GET
+  url: "{{BASE}}/api/instructor?instructor=Buzzanco"
+  params:
+    - name: instructor
+      value: Buzzanco
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/packages/vendor/src/classbrowser.uh.edu/bruno/SearchSections.yml
+++ b/src/packages/vendor/src/classbrowser.uh.edu/bruno/SearchSections.yml
@@ -1,0 +1,69 @@
+info:
+  name: SearchSections
+  type: http
+  seq: 19
+
+http:
+  method: POST
+  url: "{{BASE}}/api/courses"
+  body:
+    type: form-urlencoded
+    data:
+      - name: term
+        value: "2280"
+        disabled: true
+      - name: subject
+        value: ""
+        disabled: true
+      - name: location
+        value: ""
+        disabled: true
+      - name: limitToLocation
+        value: University of Houston
+        disabled: true
+      - name: limitToLocation
+        value: Katy Academic Building 1
+        disabled: true
+      - name: limitToLocation
+        value: UH-Sugar Land
+        disabled: true
+      - name: mode
+        value: ""
+        disabled: true
+      - name: session
+        value: ""
+        disabled: true
+      - name: coreComp
+        value: ""
+        disabled: true
+      - name: classNumber
+        value: ""
+        disabled: true
+      - name: catalogNumber
+        value: ""
+        disabled: true
+      - name: classStatus
+        value: ""
+        disabled: true
+      - name: weekendu
+        value: "0"
+        disabled: true
+      - name: day
+        value: ""
+        disabled: true
+      - name: career
+        value: GRAD
+        disabled: true
+      - name: instructor
+        value: ""
+        disabled: true
+      - name: classTime
+        value: ""
+        disabled: true
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/packages/vendor/src/classbrowser.uh.edu/bruno/Unknown_mode.yml
+++ b/src/packages/vendor/src/classbrowser.uh.edu/bruno/Unknown_mode.yml
@@ -1,0 +1,25 @@
+info:
+  name: Unknown_mode
+  type: http
+  seq: 15
+
+http:
+  method: GET
+  url: "{{BASE}}/api/online/mode?term=2280&mode=Face-to-Face&career=GRAD"
+  params:
+    - name: term
+      value: "2280"
+      type: query
+    - name: mode
+      value: Face-to-Face
+      type: query
+    - name: career
+      value: GRAD
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/packages/vendor/src/classbrowser.uh.edu/bruno/Unknown_program_level.yml
+++ b/src/packages/vendor/src/classbrowser.uh.edu/bruno/Unknown_program_level.yml
@@ -1,0 +1,25 @@
+info:
+  name: Unknown_program_level
+  type: http
+  seq: 11
+
+http:
+  method: GET
+  url: "{{BASE}}/api/online/program_level?term=2280&career=GRAD&mode="
+  params:
+    - name: term
+      value: "2280"
+      type: query
+    - name: career
+      value: GRAD
+      type: query
+    - name: mode
+      value: ""
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/packages/vendor/src/classbrowser.uh.edu/bruno/opencollection.yml
+++ b/src/packages/vendor/src/classbrowser.uh.edu/bruno/opencollection.yml
@@ -1,0 +1,10 @@
+opencollection: 1.0.0
+
+info:
+  name: classbrowser
+bundled: false
+extensions:
+  bruno:
+    ignore:
+      - node_modules
+      - .git

--- a/src/packages/vendor/src/classbrowser.uh.edu/models.ts
+++ b/src/packages/vendor/src/classbrowser.uh.edu/models.ts
@@ -1,0 +1,397 @@
+
+import { z } from 'zod'
+
+export type TermInfo = z.infer<typeof TermInfo>
+export const TermInfo = z.object({
+  /**
+   * This is the unique identifier for a "term" (Semester) that UH keeps in PeopleSoft, so it may be represented in other services as well.
+   * 
+   * There is a pattern in that the ID is usually a multiple of 10, but other than that consider it a database primary key. There is no meaningful pattern.
+   * 
+   * @example "2130" "2030"
+   */
+  term: z.string(),
+  /**
+   * This is the human-readable string that represents what time period this "term" covers
+   * 
+   * @example "Spring 2021" "Fall 2017"
+   */
+  term_descr: z.string(),
+})
+
+export type SubjectInfo = z.infer<typeof SubjectInfo>
+export const SubjectInfo = z.object({
+  /**
+   * This is the abbreviation of a subject
+   * 
+   * @example "ENGL" "GEOL"
+   */
+  subject: z.string()
+})
+
+export type EInstructionMode = z.infer<typeof EInstructionMode>
+export const EInstructionMode = z.enum([
+  'Face-to-Face',
+  'Synchronous Online',
+  'Hybrid',
+  'Asynchronous Online',
+  'Hyflex',
+  'Directed Research',
+  'Synchronous - On Campus Exams',
+  'Independent Studies',
+  'Asynchronous - On Campus Exams',
+  'Face to Face',
+  'Hyflex - On Campus Exams'
+])
+
+export type InstructionModeInfo = z.infer<typeof InstructionModeInfo>
+export const InstructionModeInfo = z.object({
+  /**
+   * This is the abbreviation of a subject
+   * 
+   * @example "ENGL" "GEOL"
+   */
+  mode: z.union([z.string(), EInstructionMode]),
+})
+
+export type InstructorInfo = z.infer<typeof InstructorInfo>
+export const InstructorInfo = z.object({
+  /**
+   * The instructor's name
+   * @example "Buzzanco,Robert"
+   */
+  instr: z.string(),
+})
+
+export type CourseInfo = z.infer<typeof CourseInfo>
+export const CourseInfo = z.object({
+  /** @example "1117" */
+  catalog_nbr: z.string(),
+  /** @example "MUSI" */
+  subject: z.string(),
+})
+
+export type ECareer = z.infer<typeof ECareer>
+/**
+ * `UGRD` => Undergraduate
+ * 
+ * `GRAD` => Graduate
+ * 
+ * `LAW` => Law
+ * 
+ * `OPT` => Optometry
+ * 
+ * `PHRM` => Pharmacy
+ * 
+ * `MED` => Medical
+ */
+export const ECareer = z.enum([
+  'UGRD',
+  'GRAD',
+  'LAW',
+  'OPT',
+  'PHRM',
+  'MED'
+]);
+
+/**
+ * Human visible descriptions for each member of `ECareer`
+ */
+export const ECareerDescription: Record<ECareer, string> = {
+  'UGRD': 'Undergraduate',
+  'GRAD': 'Graduate',
+  'LAW': 'Law',
+  'OPT': 'Optometry',
+  'PHRM': 'Pharmacy',
+  'MED': 'Medical'
+}
+
+export type EClassTime = z.infer<typeof EClassTime>
+export const EClassTime = z.enum([
+  'morning',
+  'afternoon',
+  'evening'
+])
+
+/**
+ * Human visible descriptions for each member of `EClassTime`
+ */
+export const EClassTimeDescription: Record<EClassTime, string> = {
+  'morning': 'Morning - 8:00 am - 11:30 am',
+  'afternoon': 'Afternoon - 12:00 pm - 5:30 pm',
+  'evening': 'Evening - 6:00 pm - 11:30 pm',
+}
+
+export type ECoreComponent = z.infer<typeof ECoreComponent>
+const _ECoreComponent = [10, 20, 30, 40, 50, 60, 70, 80, 81, 90] as const;
+export const ECoreComponent = z.union(_ECoreComponent.map(v => z.literal(v))); //z.enum()
+
+/**
+ * Human visible descriptions for each member of `ECoreComponent`
+ */
+export const ECoreComponentDescription = new Map<ECoreComponent, string>([
+  [10, 'Communication'],
+  [20, 'Mathematics'],
+  [30, 'Life & Physical Sciences'],
+  [40, 'Language, Philosophy & Culture'],
+  [50, 'Creative Arts'],
+  [60, 'American History'],
+  [70, 'Government/Political Science'],
+  [80, 'Social & Behavioral Science'],
+  [81, 'Writing in Discipline WID'],
+  [90, 'Math/Reasoning, Component Area Option'],
+]);
+
+export type EDayOfWeek = z.infer<typeof EDayOfWeek>
+export const EDayOfWeek = z.enum(['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'])
+
+/**
+ * Human visible descriptions for each member of `EDayOfWeek`
+ */
+export const EDayOfWeekDescription: Record<EDayOfWeek, string> = {
+  'Mo': 'Monday',
+  'Tu': 'Tuesday',
+  'We': 'Wednesday',
+  'Th': 'Thursday',
+  'Fr': 'Friday',
+  'Sa': 'Saturday'
+}
+
+export type ELocation = z.infer<typeof ELocation>
+export const ELocation = z.enum(['University of Houston', 'Katy Academic Building 1', 'UH-Sugar Land'])
+
+export type IntBool = z.infer<typeof IntBool>
+export const IntBool = z.union([z.literal(0), z.literal(1)])
+
+export type YesNo = z.infer<typeof YesNo>
+export const YesNo = z.union([z.literal('Y'), z.literal('N')])
+
+export type ESsrComponent = z.infer<typeof ESsrComponent>
+export const ESsrComponent = z.enum([
+  'LEC',
+  'LAB',
+  'SEM',
+  'IND',
+  'PRA',
+  'PRC',
+  'CLN',
+  'DST',
+  'THE',
+  'PCO',
+  'PLS',
+]);
+
+/**
+ * `A` => Active
+ * 
+ * `S` => Stop Enrollment
+ */
+export type EClassState = z.infer<typeof EClassState>
+export const EClassState = z.enum(['A', 'S']);   // Active | Stop Enrollment
+
+/**
+ * `O` => Open
+ * 
+ * `C` => Closed
+ */
+export type EEnrollmentState = z.infer<typeof EEnrollmentState>
+export const EEnrollmentState  = z.enum(['O', 'C']);   // Open   | Closed
+
+/**
+ * `E` => Enrollment
+ * 
+ * `N` => Non-enrollment
+ */
+export type EClassType = z.infer<typeof EClassType>
+export const EClassType = z.enum(['E', 'N']);   // Enrollment | Non-enrollment
+
+
+export type LocalDateTime = z.infer<typeof LocalDateTime>
+export const LocalDateTime = z.templateLiteral([z.iso.date(), " ", z.iso.time() ])
+
+export type LiveSectionResult = z.infer<typeof LiveSectionResult>
+export const LiveSectionResult = z.object({
+  /**
+   * Globally unique ID for this specific section
+   * 
+   * @example 228010055
+   */
+  id: z.number(),
+  /**
+   * The Institution ID where this section is taught
+   * 
+   * @example "00730"
+   */
+  institution: z.string(),
+  /**
+   * The ID of the "term" when this section is taught
+   * 
+   * @example "2280"
+   */
+  term: z.string(),
+  /**
+   * @example "1"
+   */
+  session_code: z.string(),
+  /**
+   * @example "H460MCL"
+   */
+  academic_org: z.string(),
+  /**
+   * @example "H0001"
+   */
+  location_code: z.string(),
+  /**
+   * @example "University of Houston", see common values in `ELocation`
+   */
+  location_descr: z.union([z.string(), ELocation]),
+  /**
+   * @example "FF"
+   */
+  instr_mode: z.string(),
+  /**
+   * @example "Face-to-Face", see common values in `EInstructionMode`
+   */
+  instr_mode_descr: z.union([z.string(), EInstructionMode]),
+  session_start_date: z.iso.date(),
+  session_end_date: z.iso.date(),
+  /**
+   * @example "ACCT"
+   */
+  subject: z.string(),
+  /**
+   * @example "6331"
+   */
+  catalog_nbr: z.string(),
+  /**
+   * @example "10055"
+   */
+  class_nbr: z.string(),
+  /**
+   * @example "01"
+   */
+  class_section: z.string(),
+  career: ECareer,
+  /**
+   * Not sure what this means
+   * @example 3
+   */
+  assoc_class: z.number(),
+  /**
+   * @example "Financial Accounting"
+   */
+  course_title: z.string(),
+  /**
+   * @example "Cr. 3. (3-0). Prerequisites: graduate standing. Introduction to transaction analysis, recording, preparation, and understanding of basic financial statements."
+   */
+  course_long_descr: z.string().nullable(),
+  course_topic_descr: z.string().nullable(),
+  topic_id: z.number(),
+  /**
+   * unknown
+   */
+  combined_section: z.string().nullable(),
+  ssr_component: ESsrComponent,
+  class_type: EClassType,
+  schedule_print: YesNo,
+  /**
+   * Uniquely identifies this course
+   */
+  course_id: z.string(),
+  course_offer_nbr: z.number(),
+  /**
+   * @example "Mo 06:00 PM-09:00 PM"
+   */
+  schedule_day_time: z.string().nullable(),
+  class_start: z.iso.time(),
+  class_end:  z.iso.time(),
+  /** @example "MH 114" */
+  building_descr: z.string().nullable(),
+  class_stat: EClassState,
+  enrl_stat: EEnrollmentState,
+  /**
+   * The number currently enrolled.
+   * @example 23
+   */
+  enrl_tot: z.number(),
+  /**
+   * The number of seats available
+   * @example 66
+   */
+  enrl_cap: z.number(),
+  /** @example "1225084" */
+  instructor_id: z.string().nullable(),
+  /** @example "Zhu,Limin" */
+  instructor_name: z.string().nullable(),
+  /**
+   * Presumably, when the API request was made.
+   * @example "2026-03-14"
+   */
+  capture_date: z.iso.date(),
+  has_syllabus: IntBool,
+  is_offcampus: IntBool,
+  is_extension: IntBool,
+  is_weekendu: IntBool,
+  is_core_curriculum: IntBool,
+  is_blackboard: IntBool,
+  created_at: LocalDateTime,
+  updated_at: LocalDateTime,
+  session: z.object({
+    id: z.number(),
+    institution: z.string(),
+    career: ECareer,
+    term: z.string(),
+    session_code: z.string(),
+    instr_weeks: z.number(),
+    /** @example "2026-01-20" */
+    session_start_date: z.iso.date(),
+    /** @example "2026-05-12" */
+    session_end_date: z.iso.date(),
+    /** @example "2026-02-04" */
+    session_census_date: z.iso.date(),
+    /** @example "2026-04-01" */
+    sixty_pct_date: z.iso.date(),
+    use_dynamic_class_date: YesNo,
+    created_at: LocalDateTime,
+    updated_at: LocalDateTime,
+  }).nullable(),
+  note: z.unknown().array(),
+})
+
+
+export type LiveSectionFilters = z.infer<typeof LiveSectionFilters>
+export const LiveSectionFilters = z.object({
+  /**
+   * term id
+   * @example "2280"
+   */
+  term: z.string(),
+  subject: z.string(),
+  //location:
+  limitToLocation: ELocation,
+  mode: EInstructionMode,
+  coreComp: ECoreComponent,
+  classNumber: z.string(),
+  catalogNumber: z.string(),
+  classStatus: z.union([z.literal('open'), z.literal('false')]),
+  /** @example "Buzzanco,Robert" */
+  instructor: z.string(),
+  classTime: EClassTime,
+  day: EDayOfWeek,
+})
+
+export type LiveSectionResponse = z.infer<typeof LiveSectionResponse>
+export const LiveSectionResponse = z.object({
+  current_page: z.number(),
+  data: LiveSectionResult.array(),
+  first_page_url: z.url().nullable(),
+  from: z.number().nullable(),
+  last_page: z.number(),
+  last_page_url: z.url().nullable(),
+  next_page_url: z.url().nullable(),
+  path: z.url().nullable(),
+  per_page: z.number(),
+  prev_page_url: z.url().nullable(),
+  to: z.number().nullable(),
+  total: z.number()
+})

--- a/src/packages/vendor/src/classbrowser.uh.edu/private/BaseApiService.ts
+++ b/src/packages/vendor/src/classbrowser.uh.edu/private/BaseApiService.ts
@@ -1,0 +1,86 @@
+import * as z4 from 'zod/v4/core'
+import { trimEnd } from 'lodash-es';
+import { isNullish } from '@cougargrades/utils/nullish';
+
+export type SearchParams = ConstructorParameters<typeof URLSearchParams>[0];
+
+export const DEFAULT_API_ORIGIN = new URL(`https://classbrowser.uh.edu`)
+
+export class BaseApiService {
+  baseURL: URL;
+
+  constructor(base?: URL) {
+    this.baseURL = base ?? DEFAULT_API_ORIGIN;
+  }
+
+  public async Get<TSchema extends z4.$ZodType>(path: string, query: SearchParams, schema: TSchema): Promise<z4.output<TSchema> | null> {
+    const params = new URLSearchParams(query);
+    const queryString: string = (
+      params.size > 0
+      ? `?${params}`
+      : ''
+    );
+
+    const res = await fetch(`${trimEnd(this.baseURL.href, '/')}${path}${queryString}`);
+    if (!res.ok) {
+      console.error(`[BaseApiService] Failed to fetch (${res.status} ${res.statusText}) at: ${path}${queryString}`);
+      return null;
+    }
+    try {
+      const data = await res.json();
+      const parsed = z4.safeParse(schema, data);
+      if (!parsed.success) {
+        console.debug(`[BaseApiService] Failed validation of JSON data with Zod Schema: ${path}${queryString}`, parsed);
+        return null;
+      }
+      return parsed.data;
+    }
+    catch (err) {
+      console.error(`[BaseApiService] Error while parsing response: ${path}${queryString}`, err);
+      return null;
+    }
+  }
+
+  public async Post<TSchema extends z4.$ZodType>(path: string, query: SearchParams, schema?: TSchema, options?: Pick<RequestInit, 'priority' | 'body'>): Promise<z4.output<TSchema> | null> {
+    const params = new URLSearchParams(query);
+    const queryString: string = (
+      params.size > 0
+      ? `?${params}`
+      : ''
+    );
+
+    const res = await fetch(`${trimEnd(this.baseURL.href, '/')}${path}${queryString}`, {
+      ...(options ?? {}),
+      method: 'POST',
+    });
+    if (!res.ok) {
+      console.error(`[BaseApiService] Failed to POST (${res.status} ${res.statusText}) at: ${path}${queryString}`);
+      return null;
+    }
+    try {
+      if (isNullish(schema)) return null;
+      const data = await res.json();
+      const parsed = z4.safeParse(schema, data);
+      if (!parsed.success) {
+        console.debug(`[BaseApiService] Failed validation of JSON data with Zod Schema: ${path}${queryString}`, parsed);
+        return null;
+      }
+      return parsed.data;
+    }
+    catch (err) {
+      console.error(`[BaseApiService] Error while parsing response: ${path}${queryString}`, err);
+      return null;
+    }
+  }
+
+  public SendBeacon(path: string, query: SearchParams, data?: BodyInit): boolean {
+    const params = new URLSearchParams(query);
+    const queryString: string = (
+      params.size > 0
+      ? `?${params}`
+      : ''
+    );
+
+    return navigator.sendBeacon(`${trimEnd(this.baseURL.href, '/')}${path}${queryString}`, data);
+  }
+}

--- a/src/packages/vendor/src/google/firestore.ts
+++ b/src/packages/vendor/src/google/firestore.ts
@@ -53,21 +53,21 @@ export function firestore(credentials: FirestoreCredentials) {
  */
 export async function* stream(query: Query, chunkSize: number = 25) {
   // If a limit or offset is already provided, then don't manipulate them
-  if (!isNullish(query._queryConstraints.limit) || !isNullish(query._queryConstraints.offset)) {
-    const snap = await query.get()
-    for(let doc of snap.docs) {
-      yield doc;
-    }
-  }
+  // if (!isNullish(query._queryConstraints.limit) || !isNullish(query._queryConstraints.offset)) {
+  //   const snap = await query.get()
+  //   for(let doc of snap.docs) {
+  //     yield doc;
+  //   }
+  // }
 
-  let i = 0;
+  let offset = query._queryConstraints.offset ?? 0;
   let snap: QuerySnapshot;
   do {
-    snap = await query.limit(chunkSize).offset(i).get();
+    snap = await query.limit(chunkSize).offset(offset).get();
     for(let doc of snap.docs) {
       yield doc;
     }
-    i += chunkSize;
+    offset += chunkSize;
   }
   while (!snap.empty);
 }

--- a/src/packages/vendor/test/classbrowser.uh.edu/catalog.test.ts
+++ b/src/packages/vendor/test/classbrowser.uh.edu/catalog.test.ts
@@ -1,0 +1,23 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { UHClassBrowserService } from '../../src/classbrowser.uh.edu/UHClassBrowserService';
+
+describe('catalog', () => {
+  let service: UHClassBrowserService;
+
+  beforeAll(() => {
+    service = new UHClassBrowserService();
+  });
+
+  it('should return >0 courses', async () => {
+    const results = await service.SearchCatalog()
+    expect(results).toBeTruthy();
+    expect(results?.length).toBeGreaterThan(0);
+  })
+
+  it('should return COOP 0011', async () => {
+    const results = await service.SearchCatalog({ subject: 'COOP' })
+    expect(results).toBeTruthy();
+    expect(results?.length).toBeGreaterThan(0);
+    expect(results?.filter(r => r.subject === 'COOP' && r.catalog_nbr === '0011').length).toBeGreaterThan(0)
+  })
+});

--- a/src/packages/vendor/test/classbrowser.uh.edu/instructors.test.ts
+++ b/src/packages/vendor/test/classbrowser.uh.edu/instructors.test.ts
@@ -8,11 +8,14 @@ describe('instructors', () => {
     service = new UHClassBrowserService();
   });
 
-  it('should return >0 instructors', async () => {
-    const results = await service.SearchInstructors('a');
-    expect(results).toBeTruthy();
-    expect(results?.length).toBeGreaterThan(0);
-  })
+  /**
+   * This will randomly fail with "500 Internal Server Error"
+   */
+  // it('should return >0 instructors', async () => {
+  //   const results = await service.SearchInstructors('a');
+  //   expect(results).toBeTruthy();
+  //   expect(results?.length).toBeGreaterThan(0);
+  // })
 
   it('should return Bob Buzzanco', async () => {
     const results = await service.SearchInstructors('Buzzanco,Robert');

--- a/src/packages/vendor/test/classbrowser.uh.edu/instructors.test.ts
+++ b/src/packages/vendor/test/classbrowser.uh.edu/instructors.test.ts
@@ -1,0 +1,22 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { UHClassBrowserService } from '../../src/classbrowser.uh.edu/UHClassBrowserService';
+
+describe('instructors', () => {
+  let service: UHClassBrowserService;
+
+  beforeAll(() => {
+    service = new UHClassBrowserService();
+  });
+
+  it('should return >0 instructors', async () => {
+    const results = await service.SearchInstructors('a');
+    expect(results).toBeTruthy();
+    expect(results?.length).toBeGreaterThan(0);
+  })
+
+  it('should return Bob Buzzanco', async () => {
+    const results = await service.SearchInstructors('Buzzanco,Robert');
+    expect(results).toBeTruthy();
+    expect(results?.length).toBeGreaterThan(0);
+  })
+});

--- a/src/packages/vendor/test/classbrowser.uh.edu/modes.test.ts
+++ b/src/packages/vendor/test/classbrowser.uh.edu/modes.test.ts
@@ -1,0 +1,16 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { UHClassBrowserService } from '../../src/classbrowser.uh.edu/UHClassBrowserService';
+
+describe('modes', () => {
+  let service: UHClassBrowserService;
+
+  beforeAll(() => {
+    service = new UHClassBrowserService();
+  });
+
+  it('should return >0 modes', async () => {
+    const modes = await service.GetAllInstructionModes();
+    expect(modes).toBeTruthy();
+    expect(modes?.length).toBeGreaterThan(0);
+  })
+});

--- a/src/packages/vendor/test/classbrowser.uh.edu/sections.test.ts
+++ b/src/packages/vendor/test/classbrowser.uh.edu/sections.test.ts
@@ -45,6 +45,6 @@ describe('sections', () => {
     const results = await service.SearchSections({ term: likelyAvailableTerm.term });
     expect(results).toBeTruthy();
     expect(results?.data.length).toBeGreaterThan(0);
-    console.log(results?.data.length ?? -1, 'sections fetched for ', likelyAvailableTerm);
+    console.log(results?.data.length ?? -1, 'sections fetched for', likelyAvailableTerm);
   })
 }, 20_000);

--- a/src/packages/vendor/test/classbrowser.uh.edu/sections.test.ts
+++ b/src/packages/vendor/test/classbrowser.uh.edu/sections.test.ts
@@ -42,9 +42,9 @@ describe('sections', () => {
     if (isNullish(likelyAvailableTerm)) throw new Error();
 
     // When no parameters are provided, an empty result is returned
-    const results = await service.SearchSections({ term: likelyAvailableTerm.term });
+    const results = await service.SearchSections({ term: likelyAvailableTerm.term, subject: "MATH" });
     expect(results).toBeTruthy();
     expect(results?.data.length).toBeGreaterThan(0);
-    console.log(results?.data.length ?? -1, 'sections fetched for', likelyAvailableTerm);
+    console.log(results?.data.length ?? -1, 'sections of MATH courses fetched for', likelyAvailableTerm);
   })
 }, 20_000);

--- a/src/packages/vendor/test/classbrowser.uh.edu/sections.test.ts
+++ b/src/packages/vendor/test/classbrowser.uh.edu/sections.test.ts
@@ -1,0 +1,50 @@
+import { assert, beforeAll, describe, expect, it } from 'vitest'
+import { Temporal } from 'temporal-polyfill'
+import { UHClassBrowserService } from '../../src/classbrowser.uh.edu/UHClassBrowserService';
+import { FormattedSeasonCode, getCurrentSeason, SeasonCode } from '@cougargrades/models';
+import { isNullish } from '@cougargrades/utils/nullish';
+
+describe('sections', () => {
+  let service: UHClassBrowserService;
+
+  beforeAll(() => {
+    service = new UHClassBrowserService();
+  });
+
+  it('should return 0 sections', async () => {
+    // When no parameters are provided, an empty result is returned
+    const results = await service.SearchSections({})
+    expect(results).toBeTruthy();
+    expect(results?.data.length).toBe(0);
+  })
+
+  it('should return >0 sections', async () => {
+    // We need to know the terms, since we need to provide one in order to test the section serach
+    const allTerms = await service.GetAllTerms();
+    assert(!isNullish(allTerms), "Could not fetch terms");
+    assert(allTerms.length > 0, "No terms are available");
+
+    // "2026"
+    const currentYear = new Date().getFullYear().toString();
+    // "01"
+    const cgSeasonCode = getCurrentSeason()
+    // "Spring"
+    const recentSeasonString = FormattedSeasonCode[cgSeasonCode];
+
+    // { "term": "2280", "term_descr": "Spring 2026" }
+    const likelyAvailableTerm = allTerms
+      .find(t =>
+        t.term_descr.includes(currentYear)
+        && t.term_descr.toLowerCase().includes(recentSeasonString.toLowerCase())
+      );
+    
+    assert(!isNullish(likelyAvailableTerm), 'Could not assess a term that is most likely to have values available');
+    if (isNullish(likelyAvailableTerm)) throw new Error();
+
+    // When no parameters are provided, an empty result is returned
+    const results = await service.SearchSections({ term: likelyAvailableTerm.term });
+    expect(results).toBeTruthy();
+    expect(results?.data.length).toBeGreaterThan(0);
+    console.log(results?.data.length ?? -1, 'sections fetched for ', likelyAvailableTerm);
+  })
+}, 20_000);

--- a/src/packages/vendor/test/classbrowser.uh.edu/subjects.test.ts
+++ b/src/packages/vendor/test/classbrowser.uh.edu/subjects.test.ts
@@ -1,0 +1,16 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { UHClassBrowserService } from '../../src/classbrowser.uh.edu/UHClassBrowserService';
+
+describe('subjects', () => {
+  let service: UHClassBrowserService;
+
+  beforeAll(() => {
+    service = new UHClassBrowserService();
+  });
+
+  it('should return >0 subjects', async () => {
+    const subjects = await service.GetAllSubjects()
+    expect(subjects).toBeTruthy();
+    expect(subjects?.length).toBeGreaterThan(0);
+  })
+});

--- a/src/packages/vendor/test/classbrowser.uh.edu/terms.test.ts
+++ b/src/packages/vendor/test/classbrowser.uh.edu/terms.test.ts
@@ -1,0 +1,16 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { UHClassBrowserService } from '../../src/classbrowser.uh.edu/UHClassBrowserService';
+
+describe('terms', () => {
+  let service: UHClassBrowserService;
+
+  beforeAll(() => {
+    service = new UHClassBrowserService();
+  });
+
+  it('should return >0 terms', async () => {
+    const terms = await service.GetAllTerms();
+    expect(terms).toBeTruthy();
+    expect(terms?.length).toBeGreaterThan(0);
+  })
+});


### PR DESCRIPTION
- Added view-based orange sparklines to Top pages
- Front-end will attempt to use corresponding "preview" API it is paired with using Cloudflare environment variables and arbitrary patterns that were noticed
- Allow infinite scrolling on Top pages
- All `<Link />` and `a[href]` will preload by "intent" (hovering over the link) by default globally
- Upgrade to Vite 8.0.0 (out of beta)
- Added classbrowser.uh.edu API bindings and test cases